### PR TITLE
Handle device issue

### DIFF
--- a/projects/train/train/data/datasets/similarity.py
+++ b/projects/train/train/data/datasets/similarity.py
@@ -18,6 +18,7 @@ class SimilarityDataset(AmplfiDataset):
         self.augmentor = augmentor
 
     def inject(self, X, cross, plus, parameters):
+
         X, psds = self.psd_estimator(X)
         dec, psi, phi = self.waveform_sampler.sample_extrinsic(X)
 
@@ -40,7 +41,6 @@ class SimilarityDataset(AmplfiDataset):
             torch.Tensor(parameters[k]) for k in self.hparams.inference_params
         ]
         parameters = torch.vstack(parameters).T
-
         X_ref = X + waveforms
         X_aug = X + augmented
         X_ref = self.whitener(X_ref, psds)

--- a/projects/train/train/data/waveforms/generator/cbc.py
+++ b/projects/train/train/data/waveforms/generator/cbc.py
@@ -49,6 +49,10 @@ class FrequencyDomainCBCGenerator(WaveformGenerator):
         """
         super().__init__(*args, **kwargs)
         waveform_arguments = waveform_arguments or {}
+
+        # set approximant (possibly torch.nn.Module) as an attribute
+        # so that it will get moved to the proper device when `.to` is called
+        self.approximant = approximant
         self.waveform = partial(approximant, **waveform_arguments)
         self.f_min = f_min
         self.f_max = f_max


### PR DESCRIPTION
Fixes bug where `approximant` was not getting moved to proper device since it was not an attribute of the `WaveformGenerator`

Streamlines how we do device handling in the base dataset