### PR TITLE
Make `FrequencyDomainCBCGenerator` robust to choices of `f_min`, `f_max`, and `padding`

### DIFF
--- a/projects/train/configs/flow/cbc.yaml
+++ b/projects/train/configs/flow/cbc.yaml
@@ -82,6 +82,7 @@ data:
         approximant: ml4gw.waveforms.IMRPhenomD
         f_min: 20
         f_max: 1024
-        padding: 1
+        ringdown_duration: 0.5
+        padding: 0.0
         waveform_arguments:
           f_ref: 40

--- a/projects/train/train/data/waveforms/generator/cbc.py
+++ b/projects/train/train/data/waveforms/generator/cbc.py
@@ -68,14 +68,17 @@ class FrequencyDomainCBCGenerator(WaveformGenerator):
     @property
     def right_pad_size(self):
         """
-        User defined value that controls where the coalescence time
-        lies relative to the right edge
+        Size of additional right padding in samples
         """
         return math.ceil(self.padding * self.sample_rate)
 
     @property
     def left_pad_size(self):
-        """ """
+        """
+        Size of left padding required to ensure
+        the waveform is sufficiently long to slice
+        according to the user requested `duration`
+        """
         # calculate the size of the time domain
         # waveform after ffting
         freq_dim = self.freq_mask.sum()


### PR DESCRIPTION
@ravioli1369 ran into an issue where the waveforms being generated were not sufficiently long enough. The underlying issue was that the number of samples in the time domain data after ffting the waveform is a function of `f_min` and `f_max`.

Another issue was the ringdown of the ffted waveform was on the left side of the waveform.

This PR does a couple of things to address these:

1. Adds `RINGDOWN_DURATION` class variable set to `0.5` seconds that will roll the waveform by that amount so that the coalescence and ringdown are properly connected. This means that by default, the waveform coalesence time is `RINGDOWN_DURATION` from the right edge of the kernel.
2. The `padding` variable  now specifies _additional_ zero padding on top of the `0.5` seconds of ringdown to add to the waveform
3. A `left_padding` variable is calculated to ensure that the waveform is long enough to fulfill the requested duration