### PR TITLE
Add optional batch norm to flows

### DIFF
--- a/amplfi/architectures/amplfi/architectures/flows/base.py
+++ b/amplfi/architectures/amplfi/architectures/flows/base.py
@@ -42,9 +42,11 @@ class FlowArchitecture(PyroModule):
 
     def build_transforms(self) -> ConditionalComposeTransformModule:
         transforms = []
-        for _ in range(self.num_transforms):
+        for i in range(self.num_transforms):
             transforms.extend([self.transform_block()])
-            if self.use_batch_norm:
+            # add batch norm after each transform
+            # except the last one
+            if i != self.num_transforms - 1 and self.use_batch_norm:
                 transforms.extend([BatchNorm(self.num_params)])
         return ConditionalComposeTransformModule(transforms)
 

--- a/amplfi/architectures/amplfi/architectures/flows/base.py
+++ b/amplfi/architectures/amplfi/architectures/flows/base.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import torch
-from pyro.distributions import ConditionalTransformedDistribution, transforms
+from pyro.distributions import ConditionalTransformedDistribution
 from pyro.distributions.conditional import ConditionalComposeTransformModule
+from pyro.distributions.transforms import BatchNorm, Transform
 from pyro.nn import PyroModule
 
 
@@ -16,12 +17,14 @@ class FlowArchitecture(PyroModule):
         embedding_net: torch.nn.Module,
         embedding_weights: Optional[Path] = None,
         freeze_embedding: bool = False,
+        use_batch_norm: bool = True,
     ):
 
         super().__init__()
         self.num_params = num_params
         self.context_dim = context_dim
         self.embedding_net = embedding_net
+        self.use_batch_norm = use_batch_norm
 
         if freeze_embedding:
             self.embedding_context = torch.no_grad
@@ -31,17 +34,19 @@ class FlowArchitecture(PyroModule):
         if embedding_weights is not None:
             self.embedding_net.load_state_dict(torch.load(embedding_weights))
 
-    def transform_block(
-        self, *args, **kwargs
-    ) -> Callable[[int], transforms.Transform]:
+    def transform_block(self, *args, **kwargs) -> Callable[[int], Transform]:
         raise NotImplementedError
 
     def distribution(self) -> torch.distributions.Distribution:
         raise NotImplementedError
 
     def build_transforms(self) -> ConditionalComposeTransformModule:
-        """Sets the ``transforms`` attribute"""
-        raise NotImplementedError
+        transforms = []
+        for _ in range(self.num_transforms):
+            transforms.extend([self.transform_block()])
+            if self.use_batch_norm:
+                transforms.extend([BatchNorm(self.num_params)])
+        return ConditionalComposeTransformModule(transforms)
 
     def flow(self) -> ConditionalTransformedDistribution:
         return ConditionalTransformedDistribution(

--- a/amplfi/architectures/amplfi/architectures/flows/coupling.py
+++ b/amplfi/architectures/amplfi/architectures/flows/coupling.py
@@ -1,6 +1,5 @@
 import pyro.distributions as dist
 import torch
-from pyro.distributions.conditional import ConditionalComposeTransformModule
 from pyro.distributions.transforms import ConditionalAffineCoupling
 from pyro.nn import ConditionalDenseNN
 
@@ -52,9 +51,3 @@ class CouplingFlow(FlowArchitecture):
             self.mean,
             self.std,
         )
-
-    def build_transforms(self):
-        transforms = []
-        for _ in range(self.num_transforms):
-            transforms.extend([self.transform_block()])
-        return ConditionalComposeTransformModule(transforms)

--- a/amplfi/architectures/amplfi/architectures/flows/iaf.py
+++ b/amplfi/architectures/amplfi/architectures/flows/iaf.py
@@ -1,6 +1,5 @@
 import torch
 import torch.distributions as dist
-from pyro.distributions.conditional import ConditionalComposeTransformModule
 from pyro.distributions.transforms import ConditionalAffineAutoregressive
 from pyro.nn import ConditionalAutoRegressiveNN
 
@@ -48,14 +47,6 @@ class InverseAutoregressiveFlow(FlowArchitecture):
             self.mean,
             self.std,
         )
-
-    def build_transforms(self):
-        """Build the transform"""
-        transforms = []
-        for _ in range(self.num_transforms):
-            transform = self.transform_block()
-            transforms.extend([transform])
-        return ConditionalComposeTransformModule(transforms)
 
 
 class MaskedAutoregressiveFlow(InverseAutoregressiveFlow):


### PR DESCRIPTION
We were missing `BatchNorm` layers between the flow transforms. This adds an optional flag that defaults to `True` which adds these layers.