### PR TITLE
log all parameters to WandB via SaveConfigCallback

### DIFF
--- a/projects/train/train/callbacks.py
+++ b/projects/train/train/callbacks.py
@@ -3,6 +3,22 @@ import shutil
 
 import h5py
 import lightning.pytorch as pl
+from lightning.pytorch.loggers import WandbLogger
+
+
+class SaveConfigCallback(pl.cli.SaveConfigCallback):
+    """
+    Override of `lightning.pytorch.cli.SaveConfigCallback` for use with WandB
+    to ensure all the hyperparameters are logged to the WandB dashboard.
+    """
+
+    def save_config(self, trainer, _, stage):
+        if stage == "fit":
+            if isinstance(trainer.logger, WandbLogger):
+                # pop off unecessary trainer args
+                config = self.config.as_dict()
+                config.pop("trainer")
+                trainer.logger.experiment.config.update(self.config.as_dict())
 
 
 class SaveAugmentedBatch(pl.Callback):

--- a/projects/train/train/cli/base.py
+++ b/projects/train/train/cli/base.py
@@ -1,11 +1,14 @@
 from lightning.pytorch.cli import LightningCLI
 
+from train.callbacks import SaveConfigCallback
+
 
 class AmplfiBaseCLI(LightningCLI):
     def __init__(self, *args, **kwargs):
         # hack into init to hardcode
         # parser_mode to omegaconf for all subclasses
         kwargs["parser_kwargs"] = {"parser_mode": "omegaconf"}
+        kwargs["save_config_callback"] = SaveConfigCallback
         super().__init__(*args, **kwargs)
 
     def add_arguments_to_parser(self, parser):


### PR DESCRIPTION
Overrides lightnings `SaveConfigCallback` to save the full config to `Wandb`. Before, we weren't saving the architecture hyperparameters.