### PR TITLE
decouple context dim from flow

### DIFF
--- a/amplfi/train/architectures/embeddings/base.py
+++ b/amplfi/train/architectures/embeddings/base.py
@@ -5,13 +5,17 @@ class Embedding(torch.nn.Module):
     """
     Dummy base class for embedding networks.
 
-    All embeddings should accept as arguments
-    `num_ifos`, `context_dim` and `strain_dim` as
-    their first through third arguments, since the
-    CLI links to this argument from the datamodule
-    at initialization time.
+    All embeddings should accept `num_ifos`
+    as their first argument. They should also
+    define a `context_dim` attribute that returns
+    the dimensionality of the output of the network,
+    which will be used to instantiate the flow transorms.
 
     This class obvioulsy isn't necessary, but leaving this
     as a reminder that we may wan't to enforce
     the above behavior more explicitly in the future
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.context_dim = None

--- a/amplfi/train/architectures/embeddings/resnet.py
+++ b/amplfi/train/architectures/embeddings/resnet.py
@@ -18,8 +18,8 @@ class ResNet(ResNet1D, Embedding):
         width_per_group: int = 64,
         stride_type: Optional[list[Literal["stride", "dilation"]]] = None,
         norm_layer: Optional[NormLayer] = None,
-        **kwargs
     ):
+
         super().__init__(
             num_ifos,
             layers=layers,
@@ -31,3 +31,7 @@ class ResNet(ResNet1D, Embedding):
             stride_type=stride_type,
             norm_layer=norm_layer,
         )
+
+        # set the context dimension so
+        # the flow can access it
+        self.context_dim = context_dim

--- a/amplfi/train/architectures/flows/base.py
+++ b/amplfi/train/architectures/flows/base.py
@@ -7,20 +7,20 @@ from pyro.distributions import ConditionalTransformedDistribution, transforms
 from pyro.distributions.conditional import ConditionalComposeTransformModule
 from pyro.nn import PyroModule
 
+from amplfi.train.architectures.embeddings.base import Embedding
+
 
 class FlowArchitecture(PyroModule):
     def __init__(
         self,
         num_params: int,
-        context_dim: int,
-        embedding_net: torch.nn.Module,
+        embedding_net: Embedding,
         embedding_weights: Optional[Path] = None,
         freeze_embedding: bool = False,
     ):
 
         super().__init__()
         self.num_params = num_params
-        self.context_dim = context_dim
         self.embedding_net = embedding_net
 
         if freeze_embedding:

--- a/amplfi/train/architectures/flows/coupling.py
+++ b/amplfi/train/architectures/flows/coupling.py
@@ -35,7 +35,7 @@ class CouplingFlow(FlowArchitecture):
         """Returns single affine coupling transform"""
         arn = ConditionalDenseNN(
             self.split_dim,
-            self.context_dim,
+            self.embedding_net.context_dim,
             [self.hidden_features],
             param_dims=[
                 self.num_params - self.split_dim,

--- a/amplfi/train/architectures/flows/iaf.py
+++ b/amplfi/train/architectures/flows/iaf.py
@@ -36,7 +36,7 @@ class InverseAutoregressiveFlow(FlowArchitecture):
         """Returns single autoregressive transform"""
         arn = ConditionalAutoRegressiveNN(
             self.num_params,
-            self.context_dim,
+            self.embedding_net.context_dim,
             self.num_blocks * [self.hidden_features],
             nonlinearity=self.activation,
         )

--- a/amplfi/train/cli/flow.py
+++ b/amplfi/train/cli/flow.py
@@ -14,12 +14,6 @@ class AmplfiFlowCLI(AmplfiBaseCLI):
         )
 
         parser.link_arguments(
-            "model.init_args.arch.init_args.context_dim",
-            "model.init_args.arch.init_args.embedding_net.init_args.context_dim",  # noqa
-            apply_on="parse",
-        )
-
-        parser.link_arguments(
             "data.init_args.ifos",
             "model.init_args.arch.init_args.embedding_net.init_args.num_ifos",
             compute_fn=lambda x: len(x),

--- a/amplfi/train/configs/flow/cbc.yaml
+++ b/amplfi/train/configs/flow/cbc.yaml
@@ -28,7 +28,6 @@ model:
         hidden_features: 150
         num_transforms: 80
         num_blocks: 6
-        context_dim: 7
         # uncomment below to load 
         # in pre-trained embedding weights
         # embedding_weights: "path/to/embedding/weights"
@@ -36,6 +35,7 @@ model:
         embedding_net: 
           class_path: amplfi.train.architectures.embeddings.ResNet
           init_args:
+            context_dim: 7
             layers: [5, 3, 3]
             norm_layer:
               class_path: ml4gw.nn.norm.GroupNorm1DGetter

--- a/amplfi/train/configs/flow/sg.yaml
+++ b/amplfi/train/configs/flow/sg.yaml
@@ -26,7 +26,6 @@ model:
         hidden_features: 150
         num_transforms: 80
         num_blocks: 6
-        context_dim: 8
         # uncomment below to load 
         # in pre-trained embedding weights
         # embedding_weights: "path/to/embedding/weights"
@@ -34,6 +33,7 @@ model:
         embedding_net: 
           class_path: amplfi.train.architectures.embeddings.ResNet
           init_args:
+            context_dim: 8
             layers: [5, 3, 3]
             norm_layer:
               class_path: ml4gw.nn.norm.GroupNorm1DGetter


### PR DESCRIPTION
Decouples `context_dim` attribute from being set in the flow. This way, we can make embeddings like the multi-modal one that take two `context_dim` parameters, `time_context_dim` and `freq_context_dim`. The `Flow` expects the `Embedding` to have an attribute `context_dim` that it can access. 

So, in the multi modal embedding for example,

```python
class MultiModal(torch.nn.Module):
    def __init__(self, num_ifos, time_domain_context, freq_domain_context):
         self.time_resnet = ResNet(time_domain_context)
         self.freq_resnet = ResNet(freq_domain_context)
         self.context = self.time_domain_context + self.freq_domain_context
```