### PR TITLE
Option for naming each run through amplfi-init

### DIFF
--- a/amplfi/amplfi_init.py
+++ b/amplfi/amplfi_init.py
@@ -152,7 +152,7 @@ def main():
     directory = (
         args.directory.resolve()
         if args.directory
-        else os.environ.get("AMPLFI_RUNDIR")
+        else Path(os.environ.get("AMPLFI_RUNDIR")).resolve()
     )
 
     if args.s3_bucket is not None and not args.s3_bucket.startswith("s3://"):

--- a/amplfi/amplfi_init.py
+++ b/amplfi/amplfi_init.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import shutil
 from pathlib import Path
 from textwrap import dedent
@@ -127,14 +128,6 @@ def main():
         "Whether to setup a tune or train pipeline",
     )
     parser.add_argument(
-        "-d",
-        "--directory",
-        type=Path,
-        required=True,
-        help="The parent directory where the "
-        "data and subdirectories for runs will be stored",
-    )
-    parser.add_argument(
         "-n",
         "--name",
         type=str,
@@ -142,10 +135,25 @@ def main():
         help="The name of the run. "
         "This will be used to create the run subdirectory.",
     )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        type=Path,
+        default=None,
+        help="The parent directory where the "
+        "data and subdirectories for runs will "
+        "be stored. If not provided, the environment "
+        "variable AMPLFI_RUNDIR will be used.",
+    )
+
     parser.add_argument("--s3-bucket")
 
     args = parser.parse_args()
-    directory = args.directory.resolve()
+    directory = (
+        args.directory.resolve()
+        if args.directory
+        else os.environ.get("AMPLFI_RUNDIR")
+    )
 
     if args.s3_bucket is not None and not args.s3_bucket.startswith("s3://"):
         raise ValueError("S3 bucket must be in the format s3://{bucket-name}/")

--- a/amplfi/amplfi_init.py
+++ b/amplfi/amplfi_init.py
@@ -67,6 +67,7 @@ def write_content(content: str, path: Path):
 
 def create_runfile(
     path: Path,
+    name: str,
     mode: Literal["flow", "similarity"],
     pipeline: Literal["tune", "train"],
     s3_bucket: Optional[Path] = None,
@@ -78,7 +79,7 @@ def create_runfile(
     config = path / "datagen.cfg"
     # make the below one string
     data_cmd = f"LAW_CONFIG_FILE={config} "
-    data_cmd += "law run amplfi.data.DataGeneration --workers 5\n"
+    data_cmd += "law run amplfi.data.DataGeneration --workers 5"
 
     if pipeline == "tune":
         train_cmd = "amplfi-tune --config tune.yaml"
@@ -89,20 +90,20 @@ def create_runfile(
     #!/bin/bash
     # set environment variables for this job
     export AMPLFI_DATADIR={base}/data/
-    export AMPLFI_OUTDIR={base}/training/
-    export AMPLFI_CONDORDIR={path}/condor
+    export AMPLFI_OUTDIR={base}/{name}/
+    export AMPLFI_CONDORDIR={path}/data/condor
 
     # set the GPUs exposed to job
     CUDA_VISIBLE_DEVICES=0
 
     # launch the data generation pipeline
     {data_cmd}
-
+    
     # launch {pipeline}ing pipeline
     {train_cmd}
     """
 
-    runfile = path / "run.sh"
+    runfile = path / name / "run.sh"
     write_content(content, runfile)
 
 
@@ -130,8 +131,16 @@ def main():
         "--directory",
         type=Path,
         required=True,
-        help="The run directory where the "
-        "configuration files will be copied to",
+        help="The parent directory where the "
+        "data and subdirectories for runs will be stored",
+    )
+    parser.add_argument(
+        "-n",
+        "--name",
+        type=str,
+        required=True,
+        help="The name of the run. "
+        "This will be used to create the run subdirectory.",
     )
     parser.add_argument("--s3-bucket")
 
@@ -151,8 +160,10 @@ def main():
         configs = TRAIN_CONFIGS[args.mode]
         configs.extend(data_config)
 
-    copy_configs(directory, configs)
-    create_runfile(directory, args.mode, args.pipeline, args.s3_bucket)
+    copy_configs(directory / args.name, configs)
+    create_runfile(
+        directory, args.name, args.mode, args.pipeline, args.s3_bucket
+    )
 
 
 if __name__ == "__main__":

--- a/amplfi/amplfi_init.py
+++ b/amplfi/amplfi_init.py
@@ -98,7 +98,7 @@ def create_runfile(
 
     # launch the data generation pipeline
     {data_cmd}
-    
+
     # launch {pipeline}ing pipeline
     {train_cmd}
     """

--- a/amplfi/amplfi_init.py
+++ b/amplfi/amplfi_init.py
@@ -115,14 +115,14 @@ def main():
         "--mode",
         choices=["flow", "similarity"],
         default="flow",
-        help="Either 'flow' or 'similarity',"
+        help="Either 'flow' or 'similarity'. "
         "Whether to setup a flow or similarity training",
     )
     parser.add_argument(
         "--pipeline",
         choices=["tune", "train"],
         default="train",
-        help="Either 'train' or 'tune'."
+        help="Either 'train' or 'tune'. "
         "Whether to setup a tune or train pipeline",
     )
     parser.add_argument(
@@ -130,7 +130,7 @@ def main():
         "--directory",
         type=Path,
         required=True,
-        help="The run directory where the"
+        help="The run directory where the "
         "configuration files will be copied to",
     )
     parser.add_argument("--s3-bucket")

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,6 +1,6 @@
 Running in Containers
 =====================
-`AMPLFI` also provides a container builds available via the github container repository
+`AMPLFI` also provides container builds available via the github container repository
 
 You can pull the container locally with either docker or apptainer
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,6 +1,6 @@
 Running in Containers
 =====================
-`AMPLFI` also provides container builds available via the github container repository
+`AMPLFI` also provides a container build available via the github container repository
 
 You can pull the container locally with either docker or apptainer
 

--- a/docs/first_pipeline.md
+++ b/docs/first_pipeline.md
@@ -10,27 +10,33 @@ After [installing](./installation.md) `AMPLFI`, you will have access to the `amp
 
 ```console
 > amplfi-init --help
+usage: amplfi-init [-h] [--mode {flow,similarity}] [--pipeline {tune,train}] [-d DIRECTORY]
+                   [-n NAME] [--s3-bucket S3_BUCKET]
 
-usage: amplfi-init [-h] [--mode {flow,similarity}] [--pipeline {tune,train}] [-d DIRECTORY] [--s3-bucket S3_BUCKET]
+Initialize a directory with configuration files for running end-to-end amplfi training or
+tuning pipelines
 
-Initialize a directory with configuration files for running end-to-end amplfi training or tuning pipelines
-
-optional arguments:
+options:
   -h, --help            Show this help message and exit.
   --mode {flow,similarity}
-                        Either 'flow' or 'similarity',Whether to setup a flow or similarity training (default: flow)
+                        Either 'flow' or 'similarity', Whether to setup a flow or similarity
+                        training (default: flow)
   --pipeline {tune,train}
-                        Either 'train' or 'tune'.Whether to setup a tune or train pipeline (default: train)
+                        Either 'train' or 'tune'. Whether to setup a tune or train pipeline
+                        (default: train)
   -d DIRECTORY, --directory DIRECTORY
-                        The run directory where theconfiguration files will be copied to (required, type: <class 'Path'>)
+                        The parent directory where the data and subdirectories for runs will
+                        be stored (required, type: <class 'Path'>)
+  -n NAME, --name NAME  The name of the run. This will be used to create a the run
+                        subdirectory. (required, type: str)
   --s3-bucket S3_BUCKET
                         (default: null)
 ```
 
-For example, let's initialize a run directory at `~/amplfi/my-first-run` for training a normalizing flow
+For example, let's initialize a run directory at `~/amplfi/my-runs` for training a normalizing flow, and name it `first-flow-run`:
 
 ```console
-amplfi-init --mode flow --pipeline train --directory ~/amplfi/flow-run
+amplfi-init --mode flow --pipeline train --directory ~/amplfi/my-runs --name first-flow-run
 ```
 
 A `run.sh` will be created in the run directory that will look like:
@@ -38,15 +44,15 @@ A `run.sh` will be created in the run directory that will look like:
 ```bash
 #!/bin/bash
 # Export environment variables
-export AMPLFI_DATADIR=/home/albert.einstein/amplfi/data/
-export AMPLFI_OUTDIR=/home/albert.einstein/amplfi/my-first-run/training/
-export AMPLFI_CONDORDIR=/home/albert.einstein/amplfi/my-first-run/data/condor
+export AMPLFI_DATADIR=/home/albert.einstein/amplfi/my-runs/data/
+export AMPLFI_OUTDIR=/home/albert.einstein/amplfi/my-runs/first-flow-run/
+export AMPLFI_CONDORDIR=/home/albert.einstein/amplfi/my-runs/data/condor
 
 # launch the data generation pipeline
 LAW_CONFIG_FILE=/home/albert.einstein/amplfi/my-first-run/datagen.cfg law run amplfi.data.DataGeneration --workers 5
 
 # launch training pipeline
-amplfi-train-flow fit --config cbc.yaml
+amplfi-flow-cli fit --config cbc.yaml
 ```
 
 This bash script consists of two steps:

--- a/docs/first_pipeline.md
+++ b/docs/first_pipeline.md
@@ -10,25 +10,19 @@ After [installing](./installation.md) `AMPLFI`, you will have access to the `amp
 
 ```console
 > amplfi-init --help
-usage: amplfi-init [-h] [--mode {flow,similarity}] [--pipeline {tune,train}] [-d DIRECTORY]
-                   [-n NAME] [--s3-bucket S3_BUCKET]
+usage: amplfi-init [-h] [--mode {flow,similarity}] [--pipeline {tune,train}] [-n NAME] [-d DIRECTORY] [--s3-bucket S3_BUCKET]
 
-Initialize a directory with configuration files for running end-to-end amplfi training or
-tuning pipelines
+Initialize a directory with configuration files for running end-to-end amplfi training or tuning pipelines
 
 options:
   -h, --help            Show this help message and exit.
   --mode {flow,similarity}
-                        Either 'flow' or 'similarity', Whether to setup a flow or similarity
-                        training (default: flow)
+                        Either 'flow' or 'similarity'. Whether to setup a flow or similarity training (default: flow)
   --pipeline {tune,train}
-                        Either 'train' or 'tune'. Whether to setup a tune or train pipeline
-                        (default: train)
+                        Either 'train' or 'tune'. Whether to setup a tune or train pipeline (default: train)
+  -n NAME, --name NAME  The name of the run. This will be used to create the run subdirectory. (required, type: str)
   -d DIRECTORY, --directory DIRECTORY
-                        The parent directory where the data and subdirectories for runs will
-                        be stored (required, type: <class 'Path'>)
-  -n NAME, --name NAME  The name of the run. This will be used to create a the run
-                        subdirectory. (required, type: str)
+                        The parent directory where the data and subdirectories for runs will be stored. If not provided, the environment variable AMPLFI_RUNDIR will be used. (type: <class 'Path'>, default: null)
   --s3-bucket S3_BUCKET
                         (default: null)
 ```
@@ -37,6 +31,13 @@ For example, let's initialize a run directory at `~/amplfi/my-runs` for training
 
 ```console
 amplfi-init --mode flow --pipeline train --directory ~/amplfi/my-runs --name first-flow-run
+```
+
+Alternatively the `--directory` argument can be skipped by defining the `AMPLFI_RUNDIR` environment variable. This will be used as the parent directory for all runs.
+
+```console
+export AMPLFI_RUNDIR=~/amplfi/my-runs
+amplfi-init --mode flow --pipeline train --name first-flow-run
 ```
 
 A `run.sh` will be created in the run directory that will look like:


### PR DESCRIPTION
Added a parser to name each run, so the runs are contained in a parent directory defined by `--directory` and each run is in a subdirectory defined by `--name`. 

I was trying to go for a structure like this:

```.
└── amplfi-runs
    ├── data
    │   ├── condor
    │   ├── test
    │   └── train
    ├── first-run
    │   ├── cbc.yaml
    │   ├── datagen.cfg
    │   └── run.sh
    └── second-run
        ├── cbc.yaml
        ├── datagen.cfg
        └── run.sh
```

Though, I'm not exactly sure where the condor directory would go.