### PR TITLE
Add `/opt/env/bin` to `PATH` in container 

### DIFF
--- a/apptainer.def
+++ b/apptainer.def
@@ -34,6 +34,9 @@ micromamba shell init --shell=bash --root-prefix=~/micromamba
 export PATH=/opt/env/bin:$PATH
 echo export PATH=$PATH >> /etc/profile
 
+%environment
+    export PATH=/opt/env/bin:$PATH
+    
 %runscript
 #!/bin/bash
 eval "$(micromamba shell hook --shell bash)"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7193,4 +7193,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "335b3bfccff3bac8fda709148ff9dc0c1852985a1af501ab01249aea1bcfe40b"
+content-hash = "694fe9a482cfb4e6c75fa51868a9eb915f2de7f66b1aa19276ea08a42871e3dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ numpy = "<2.0.0"
 lightning = "<=2.2.1"
 ml4gw = "^0.5"
 h5py = "^3.10.0"
-ray = "^2.9.3"
+ray = {version = "^2.9.3", extras = ["default", "tune"]}
 bilby = "^2.2.3"
 healpy = "^1.16.6"
 pyro-ppl = "^1.9.0"


### PR DESCRIPTION
Useful when programs use `apptainer exec` or `apptainer shell`