### PR TITLE
Change install path of `mamba` env in container

### DIFF
--- a/amplfi/data/base.py
+++ b/amplfi/data/base.py
@@ -48,6 +48,9 @@ class AmplfiDataSandbox(DataSandbox):
         config[f"singularity_sandbox_{cls.sandbox_type}"][
             "forward_law"
         ] = False
+        config[f"singularity_sandbox_{cls.sandbox_type}"][
+            "law_executable"
+        ] = "/env/bin/law"
         return config
 
 

--- a/apptainer.def
+++ b/apptainer.def
@@ -11,7 +11,6 @@ conda-lock.yml /opt/amplfi/conda-lock.yml
 %post
 mkdir -p /cvmfs /hdfs /gpfs /ceph /hadoop
 
-
 # install git for pip installation from github
 apt-get update
 apt-get install -y --no-install-recommends git

--- a/apptainer.def
+++ b/apptainer.def
@@ -11,6 +11,7 @@ conda-lock.yml /opt/amplfi/conda-lock.yml
 %post
 mkdir -p /cvmfs /hdfs /gpfs /ceph /hadoop
 
+
 # install git for pip installation from github
 apt-get update
 apt-get install -y --no-install-recommends git
@@ -18,10 +19,10 @@ apt-get clean
 
 # activate micromamba and create environment from lockfile
 /bin/bash /root/.bashrc
-micromamba create -p /opt/env -f /opt/amplfi/conda-lock.yml
+micromamba create -p /env -f /opt/amplfi/conda-lock.yml
 
 cd /opt/amplfi
-micromamba run -p /opt/env python -m pip install -e .
+micromamba run -p /env python -m pip install -e .
 
 # initialize our shell so that we can execute
 # commands in our environment at run time
@@ -31,14 +32,14 @@ micromamba shell init --shell=bash --root-prefix=~/micromamba
 # set path, and add it to /etc/profile
 # so that it will be set if login shell
 # is invoked
-export PATH=/opt/env/bin:$PATH
+export PATH=/env/bin:$PATH
 echo export PATH=$PATH >> /etc/profile
 
 %environment
-    export PATH=/opt/env/bin:$PATH
+    export PATH=/env/bin:$PATH
     
 %runscript
 #!/bin/bash
 eval "$(micromamba shell hook --shell bash)"
-micromamba activate /opt/env
+micromamba activate /env
 exec "$@"

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -38,7 +38,7 @@ so they can be accessed inside the container.
 
 ## Mounting Local Code
 During development, often times you will make code changes and want to test them inside the container.
-To do so, you *could* rebuild the entire container locally so that your changes are built into the container,
+To do so, you *could* rebuild the entire container locally so that your changes are reflected in the container,
 
 ```
 apptainer build $AMPLFI_CONTAINER_ROOT/amplfi.sif apptainer.def

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -47,11 +47,11 @@ apptainer build $AMPLFI_CONTAINER_ROOT/amplfi.sif apptainer.def
 but it can be quite cumbersome to do this each time you make a minor tweak to the code base.
 
 Fortunately, `AMPLFI` is installed editably inside the container at the path `/opt/amplfi`. So,
-it is possible to map local changes into the container at runtime by bind mounting your local repository. As an example, the above training command can be modified to do so using the `-B` flag.
+it is possible to map local changes into the container at runtime by bind mounting your local repository. As an example, the above training command can be modified to do so using the `-B` flag (replace `/path/to/local/amplfi` with the location where your local amplfi lives).
 
 ```console 
 APPTAINERENV_AMPLFI_OUTDIR=/path/to/outdir APPTAINERENV_AMPLFI_OUTDIR=/path/to/datadir/ \
-    apptainer run -B /path/to/amplfi:/opt/amplfi --nv $AMPLFI_CONTAINER_ROOT/amplfi.sif amplfi-flow-cli fit --config /path/to/config.yaml
+    apptainer run -B /path/to/local/amplfi:/opt/amplfi --nv $AMPLFI_CONTAINER_ROOT/amplfi.sif amplfi-flow-cli fit --config /path/to/config.yaml
 ```
 
 ```{eval-rst}

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -56,6 +56,6 @@ APPTAINERENV_AMPLFI_OUTDIR=/path/to/outdir APPTAINERENV_AMPLFI_OUTDIR=/path/to/d
 
 ```{eval-rst}
 .. note::
-   If you make modifications the the enviroment like adding python dependencies you will
+   If you make modifications the the environment like adding python dependencies you will
    have to rebuild the containers!
 ```

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -47,10 +47,9 @@ apptainer build $AMPLFI_CONTAINER_ROOT/amplfi.sif apptainer.def
 but it can be quite cumbersome to do this each time you make a minor tweak to the code base.
 
 Fortunately, `AMPLFI` is installed editably inside the container at the path `/opt/amplfi`. So,
-it is possible to map local changes into the container at runtime by bind mounting your local repository.
-As an example, the above training command can be modified using the `-B` flag to map in your local repository 
+it is possible to map local changes into the container at runtime by bind mounting your local repository. As an example, the above training command can be modified to do so using the `-B` flag.
 
-```console
+```console 
 APPTAINERENV_AMPLFI_OUTDIR=/path/to/outdir APPTAINERENV_AMPLFI_OUTDIR=/path/to/datadir/ \
     apptainer run -B /path/to/amplfi:/opt/amplfi --nv $AMPLFI_CONTAINER_ROOT/amplfi.sif amplfi-flow-cli fit --config /path/to/config.yaml
 ```

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -34,3 +34,29 @@ APPTAINERENV_AMPLFI_OUTDIR=/path/to/outdir APPTAINERENV_AMPLFI_OUTDIR=/path/to/d
 
 Note that we must map in the `APPTAINERENV_AMPLFI_OUTDIR` and `APPTAINERENV_AMPLFI_DATADIR` environment variables
 so they can be accessed inside the container.
+
+
+## Mounting Local Code
+During development, often times you will make code changes and want to test them inside the container.
+To do so, you *could* rebuild the entire container locally so that your changes are built into the container,
+
+```
+apptainer build $AMPLFI_CONTAINER_ROOT/amplfi.sif apptainer.def
+```
+
+but it can be quite cumbersome to do this each time you make a minor tweak to the code base.
+
+Fortunately, `AMPLFI` is installed editably inside the container at the path `/opt/amplfi`. So,
+it is possible to map local changes into the container at runtime by bind mounting your local repository.
+As an example, the above training command can be modified using the `-B` flag to map in your local repository 
+
+```console
+APPTAINERENV_AMPLFI_OUTDIR=/path/to/outdir APPTAINERENV_AMPLFI_OUTDIR=/path/to/datadir/ \
+    apptainer run -B /path/to/amplfi:/opt/amplfi --nv $AMPLFI_CONTAINER_ROOT/amplfi.sif amplfi-flow-cli fit --config /path/to/config.yaml
+```
+
+```{eval-rst}
+.. note::
+   If you make modifications the the enviroment like adding python dependencies you will
+   have to rebuild the containers!
+```


### PR DESCRIPTION
1. Changes install path of `mamba` env in container due to conflict when mounting code on nautilius
2. Adds documentation on mounting local code into containers at runtime