### PR TITLE
Adds optional `jitter` parameter

### DIFF
--- a/amplfi/train/data/augmentors.py
+++ b/amplfi/train/data/augmentors.py
@@ -28,7 +28,6 @@ class TimeTranslator(torch.nn.Module):
         shifts = 2 * self.jitter * shifts - self.jitter
         shifts *= self.sample_rate
         shifts = shifts.long()
-
         indices = (
             torch.arange(waveforms.size(-1), device=waveforms.device)
             .unsqueeze(0)

--- a/amplfi/train/data/waveforms/generator/cbc.py
+++ b/amplfi/train/data/waveforms/generator/cbc.py
@@ -164,7 +164,10 @@ class FrequencyDomainCBCGenerator(WaveformGenerator):
         # relative to the right edge, so just subtract
         # the pre-whiten kernel size from the right edge and slice
         start = waveforms.shape[-1] - self.waveform_size
-        return waveforms[..., start:]
+        waveforms = waveforms[..., start:]
+        if self.time_translator is not None:
+            waveforms = self.time_translator(waveforms)
+        return waveforms
 
     def forward(self, **parameters):
         hc, hp = self.time_domain_strain(**parameters)

--- a/amplfi/train/data/waveforms/generator/generator.py
+++ b/amplfi/train/data/waveforms/generator/generator.py
@@ -33,6 +33,12 @@ class WaveformGenerator(WaveformSampler):
             parameter_sampler:
                 A callable that takes an integer N and
                 returns a dictionary of parameter Tensors, each of length `N`
+            test_parameter_sampler:
+                A callable that takes an integer N and
+                returns a dictionary of parameter Tensors, each of length `N`.
+                Used for sampling test waveforms from a prior
+                different from training data.
+                If None, `parameter_sampler` is used.
             num_fit_params:
                 The number of parameters used to fit standard scaler
 

--- a/amplfi/train/data/waveforms/sampler.py
+++ b/amplfi/train/data/waveforms/sampler.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 
+from ..augmentors import TimeTranslator
 from ..utils.utils import ParameterTransformer
 
 Distribution = torch.distributions.Distribution
@@ -26,6 +27,9 @@ class WaveformSampler(torch.nn.Module):
             The distribution of polarization angles to sample from
         phi:
             The distribution of "right ascensions" to sample from
+        jitter:
+            The amount of jitter in seconds to randomly shift
+            the waveform coalescence time. If `None`, no jitter is applied.
     """
 
     def __init__(
@@ -36,6 +40,7 @@ class WaveformSampler(torch.nn.Module):
         dec: Distribution,
         psi: Distribution,
         phi: Distribution,
+        jitter: Optional[float] = None,
         parameter_transformer: Optional[ParameterTransformer] = None,
     ) -> None:
 
@@ -45,6 +50,9 @@ class WaveformSampler(torch.nn.Module):
         self.duration = duration
         self.sample_rate = sample_rate
         self.dec, self.psi, self.phi = dec, psi, phi
+        self.time_translator = (
+            TimeTranslator(jitter, sample_rate) if jitter is not None else None
+        )
 
     def sample_extrinsic(self, X: torch.Tensor):
         """


### PR DESCRIPTION
Adds `jitter` float parameter that specifies, in seconds, how much the coalescence time can vary from the default location 
For CBC waveforms this default is `ringdown_duration` + `padding` seconds from the right edge of the kernel. 

So if `jitter = 0.1` the waveform coalescence can be `+/- 0.1` from the default location. 