### PR TITLE
Bump version to `v0.2.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amplfi"
-version = "0.1.1"
+version = "0.2.0"
 description = "Accelerated Multi-messenger PE with Likelihood Free Inference"
 authors = [
     "Ethan Marx",


### PR DESCRIPTION
Prepare for `v0.2.0` release. This is needed so that `aframe` can utilize the multimodal embedding which didn't make our initial release. 