### PR TITLE
Fix waveform placement bug when changing `fduration`

### DIFF
--- a/amplfi/train/cli/base.py
+++ b/amplfi/train/cli/base.py
@@ -20,9 +20,14 @@ class AmplfiBaseCLI(LightningCLI):
         )
 
         parser.link_arguments(
-            ("data.init_args.kernel_length", "data.init_args.fduration"),
-            "data.init_args.waveform_sampler.init_args.duration",
-            compute_fn=lambda *x: sum(x),
+            "data.init_args.kernel_length",
+            "data.init_args.waveform_sampler.init_args.kernel_length",
+            apply_on="parse",
+        )
+
+        parser.link_arguments(
+            "data.init_args.fduration",
+            "data.init_args.waveform_sampler.init_args.fduration",
             apply_on="parse",
         )
 

--- a/amplfi/train/data/waveforms/generator/cbc.py
+++ b/amplfi/train/data/waveforms/generator/cbc.py
@@ -115,11 +115,16 @@ class FrequencyDomainCBCGenerator(WaveformGenerator):
         hc *= self.sample_rate
         hp *= self.sample_rate
 
-        # roll the waveforms to join
-        # the coalescence and ringdown
-        ringdown_size = int(self.ringdown_duration * self.sample_rate)
-        hc = torch.roll(hc, -ringdown_size, dims=-1)
-        hp = torch.roll(hp, -ringdown_size, dims=-1)
+        # roll the waveforms to join the coalescence and ringdown;
+        # account for the data lost due to the whitening filter;
+        # after whitening, the coalescence time will be placed
+        # `self.ringdown_duration` seconds from the right edge
+        roll_size = int(
+            (self.ringdown_duration + self.fduration / 2) * self.sample_rate
+        )
+
+        hc = torch.roll(hc, -roll_size, dims=-1)
+        hp = torch.roll(hp, -roll_size, dims=-1)
 
         return hc, hp
 

--- a/amplfi/train/data/waveforms/sampler.py
+++ b/amplfi/train/data/waveforms/sampler.py
@@ -34,7 +34,8 @@ class WaveformSampler(torch.nn.Module):
 
     def __init__(
         self,
-        duration: float,
+        fduration: float,
+        kernel_length: float,
         sample_rate: float,
         inference_params: list[str],
         dec: Distribution,
@@ -47,7 +48,9 @@ class WaveformSampler(torch.nn.Module):
         super().__init__()
         self.parameter_transformer = parameter_transformer or (lambda x: x)
         self.inference_params = inference_params
-        self.duration = duration
+        self.fduration = fduration
+        self.kernel_length = kernel_length
+
         self.sample_rate = sample_rate
         self.dec, self.psi, self.phi = dec, psi, phi
         self.time_translator = (
@@ -63,6 +66,14 @@ class WaveformSampler(torch.nn.Module):
         psi = self.psi.sample((N,)).to(X.device)
         phi = self.phi.sample((N,)).to(X.device)
         return dec, psi, phi
+
+    @property
+    def duration(self):
+        """
+        Length of kernel before whitening removes
+        fduration / 2 from each side
+        """
+        return self.fduration + self.kernel_length
 
     @property
     def waveform_size(self):

--- a/amplfi/train/priors.py
+++ b/amplfi/train/priors.py
@@ -36,7 +36,7 @@ def cbc_prior() -> ParameterSampler:
         ),
         distance=Uniform(
             torch.as_tensor(100, dtype=torch.float32),
-            torch.as_tensor(3100, dtype=torch.float32),
+            torch.as_tensor(200, dtype=torch.float32),
         ),
         inclination=distributions.Sine(
             torch.as_tensor(0, dtype=torch.float32),

--- a/amplfi/train/priors.py
+++ b/amplfi/train/priors.py
@@ -36,7 +36,7 @@ def cbc_prior() -> ParameterSampler:
         ),
         distance=Uniform(
             torch.as_tensor(100, dtype=torch.float32),
-            torch.as_tensor(200, dtype=torch.float32),
+            torch.as_tensor(3100, dtype=torch.float32),
         ),
         inclination=distributions.Sine(
             torch.as_tensor(0, dtype=torch.float32),


### PR DESCRIPTION
I was looking at resolving those spikes we were seeing in the fft'd data, and they seem to go away simply by increasing `fduration` to 2 seconds. 

This led me to discover a minor bug in or waveform generation that wasn't accounting for the `fduration` properly when placing the waveform in the kernel. In previous runs, we happened to get lucky with our specific parameters. This PR fixes this issue so users can specify different `fduration` parameters.

