### PR TITLE
Config and other miscellaneous updates

### DIFF
--- a/amplfi/train/configs/flow/cbc.yaml
+++ b/amplfi/train/configs/flow/cbc.yaml
@@ -16,16 +16,28 @@ trainer:
   check_val_every_n_epoch: 1
   log_every_n_steps: 50
   benchmark: false
+  callbacks:
+    - class_path: amplfi.train.callbacks.ModelCheckpoint
+      init_args:
+        monitor: "valid_loss"
+        save_top_k: 5
+        save_last: true
+        auto_insert_metric_name : false
+        mode: "min"
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: epoch
 model:
   class_path: amplfi.train.models.flow.FlowModel
   init_args:
     outdir: ${oc.env:AMPLFI_OUTDIR}
-    # add path below when running `trainer.test` to load in a checkpoint
-    checkpoint: null
+    nside: 32
+    samples_per_event: 10000
+    num_corner: 50
     arch:
       class_path: amplfi.train.architectures.flows.MaskedAutoregressiveFlow
       init_args:
-        transform_type: "affine"
+        transform_type: "spline"
         hidden_features: 128
         num_transforms: 80
         num_blocks: 6
@@ -44,7 +56,7 @@ model:
               class_path: ml4gw.nn.norm.GroupNorm1DGetter
               init_args:
                 groups: 8
-    patience: null
+    patience: 40
     learning_rate: 0.00071444
     weight_decay: 0.0
 data:
@@ -55,7 +67,7 @@ data:
     highpass: 25
     sample_rate: 2048
     kernel_length: 3
-    fduration: 1
+    fduration: 2
     psd_length: 10
     fftlength: 2
     batches_per_epoch: 800

--- a/amplfi/train/configs/flow/sg.yaml
+++ b/amplfi/train/configs/flow/sg.yaml
@@ -31,6 +31,9 @@ model:
   class_path: amplfi.train.models.flow.FlowModel
   init_args:
     outdir: ${oc.env:AMPLFI_OUTDIR}
+    nside: 32
+    samples_per_event: 10000
+    num_corner: 50
     arch:
       class_path: amplfi.train.architectures.flows.InverseAutoregressiveFlow
       init_args:
@@ -62,7 +65,7 @@ data:
     highpass: 25
     sample_rate: 2048
     kernel_length: 5
-    fduration: 1
+    fduration: 2
     psd_length: 12
     fftlength: 2
     batches_per_epoch: 200

--- a/amplfi/train/models/base.py
+++ b/amplfi/train/models/base.py
@@ -2,7 +2,6 @@ import logging
 import math
 import sys
 from pathlib import Path
-from typing import Optional
 
 import lightning.pytorch as pl
 import torch
@@ -35,7 +34,6 @@ class AmplfiModel(pl.LightningModule):
         weight_decay: float = 0.0,
         patience: int = 10,
         factor: float = 0.1,
-        checkpoint: Optional[Path] = None,
         verbose: bool = False,
     ):
         super().__init__()
@@ -45,21 +43,12 @@ class AmplfiModel(pl.LightningModule):
         self.outdir = outdir
         outdir.mkdir(exist_ok=True, parents=True)
         self.inference_params = inference_params
-        self.checkpoint = checkpoint
+
         self.save_hyperparameters()
 
         # initialize an unfit scaler here so that it is available
         # for the LightningModule to save and load from checkpoints
         self.scaler = ChannelWiseScaler(len(inference_params))
-
-    def maybe_load_checkpoint(self, checkpoint: Optional[Path] = None):
-        if checkpoint is not None:
-            self._logger.info(
-                f"Loading model weights from checkpoint path: {checkpoint}"
-            )
-            map_location = None if torch.cuda.is_available() else "cpu"
-            checkpoint = torch.load(checkpoint, map_location=map_location)
-            self.load_state_dict(checkpoint["state_dict"])
 
     def init_logging(self, verbose):
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -180,5 +180,7 @@ class FlowModel(AmplfiModel):
         plt.xlabel("Searched Area (deg^2)")
         plt.ylabel("Cumulative Probability")
         plt.title("Searched Area Cumulative Distribution Function")
+        plt.grid()
+        plt.axhline(0.5, color="grey", linestyle="--")
         plt.savefig(self.outdir / "searched_area.png")
         np.save(self.outdir / "searched_area.npy", searched_areas)

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -44,10 +44,6 @@ class FlowModel(AmplfiModel):
         # save our hyperparameters
         self.save_hyperparameters(ignore=["arch"])
 
-        # if checkpoint is not None, load in model weights;
-        # checkpint should only be specified here if running trainer.test
-        self.maybe_load_checkpoint(self.checkpoint)
-
     def forward(self, context, parameters) -> Tensor:
         return -self.model.log_prob(parameters, context=context)
 

--- a/amplfi/train/models/similarity.py
+++ b/amplfi/train/models/similarity.py
@@ -26,11 +26,6 @@ class SimilarityModel(AmplfiModel):
         self.model = arch
         self.similarity_loss = similarity_loss
 
-        # if checkpoint is not None, load in model weights;
-        # checkpoint should only be specified in this way
-        # if running trainer.test
-        self.maybe_load_checkpoint(self.checkpoint)
-
     def forward(
         self,
         ref,


### PR DESCRIPTION
- Changes `fduration` to 2
- Explicitly include `nside`, `num_corner`, `samples_per_event`
- Remove `checkpoint` argument since lightning has a built in `--ckpt_path`
- Add aesthetic improvements to searched area plot
- Support multiple testing background files