### PR TITLE
Test step and config updates

### DIFF
--- a/amplfi/train/configs/flow/cbc.yaml
+++ b/amplfi/train/configs/flow/cbc.yaml
@@ -92,8 +92,8 @@ data:
         phi: 
           class_path: torch.distributions.Uniform
           init_args:
-            low: -3.14
-            high: 3.14
+            low: 0
+            high: 6.28
         num_val_waveforms: 10000
         num_test_waveforms: 200
         approximant: ml4gw.waveforms.IMRPhenomD

--- a/amplfi/train/configs/similarity/cbc.yaml
+++ b/amplfi/train/configs/similarity/cbc.yaml
@@ -88,8 +88,8 @@ data:
         phi: 
           class_path: torch.distributions.Uniform
           init_args:
-            low: -3.14
-            high: 3.14
+            low: 0
+            high: 6.28
         num_val_waveforms: 10000
         num_test_waveforms: 200
         approximant: ml4gw.waveforms.IMRPhenomD

--- a/amplfi/train/data/datasets/testing/mdc.py
+++ b/amplfi/train/data/datasets/testing/mdc.py
@@ -21,8 +21,6 @@ def phi_from_ra(ra: np.ndarray, gpstimes: np.ndarray) -> float:
     # calculate the relative azimuthal angle in the range [0, 2pi]
     phi = np.remainder(ra - gmsts, 2 * np.pi)
 
-    # convert to range [-pi, pi]
-    phi[phi > np.pi] -= 2 * np.pi
     return phi
 
 

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -168,9 +168,15 @@ class FlowModel(AmplfiModel):
 
         # searched area cum hist
         searched_areas = []
+        fifty_percent_areas = []
+        ninety_percent_areas = []
         for result in self.test_results:
-            searched_area = result.calculate_searched_area(self.nside)
+            searched_area, fifty, ninety = result.calculate_searched_area(
+                self.nside
+            )
             searched_areas.append(searched_area)
+            fifty_percent_areas.append(fifty)
+            ninety_percent_areas.append(ninety)
         searched_areas = np.sort(searched_areas)
         counts = np.arange(1, len(searched_areas) + 1) / len(searched_areas)
 
@@ -184,3 +190,15 @@ class FlowModel(AmplfiModel):
         plt.axhline(0.5, color="grey", linestyle="--")
         plt.savefig(self.outdir / "searched_area.png")
         np.save(self.outdir / "searched_area.npy", searched_areas)
+
+        plt.close()
+        plt.figure(figsize=(10, 6))
+        mm, bb, pp = plt.hist(
+            fifty_percent_areas, label="50 percent area", bins=50
+        )
+        _, _, _ = plt.hist(
+            ninety_percent_areas, label="90 percent area", bins=bb
+        )
+        plt.xlabel("Sq. deg.")
+        plt.legend()
+        plt.savefig(self.outdir / "fifty_ninety_areas.png")

--- a/amplfi/train/testing.py
+++ b/amplfi/train/testing.py
@@ -27,7 +27,7 @@ def get_sky_projection(ra, dec, dist, nside=32, min_samples_per_pix=15):
     """
     theta = np.pi / 2 - dec
     # mask out non physical samples;
-    mask = (ra > -np.pi) * (ra < np.pi)
+    mask = (ra > 0) * (ra < 2*np.pi)
     mask &= (theta > 0) * (theta < np.pi)
 
     ra = ra[mask]

--- a/amplfi/train/testing.py
+++ b/amplfi/train/testing.py
@@ -27,7 +27,7 @@ def get_sky_projection(ra, dec, dist, nside=32, min_samples_per_pix=15):
     """
     theta = np.pi / 2 - dec
     # mask out non physical samples;
-    mask = (ra > 0) * (ra < 2*np.pi)
+    mask = (ra > 0) * (ra < 2 * np.pi)
     mask &= (theta > 0) * (theta < np.pi)
 
     ra = ra[mask]

--- a/amplfi/train/testing.py
+++ b/amplfi/train/testing.py
@@ -116,7 +116,14 @@ class Result(bilby.result.Result):
         searched_area = num_pix_before_injection * hp.nside2pixarea(
             nside, degrees=True
         )
-        return searched_area
+        healpix_cumsum = np.cumsum(healpix[sorted_idxs])
+        fifty = np.argmin(healpix_cumsum < 0.5) * hp.nside2pixarea(
+            nside, degrees=True
+        )
+        ninety = np.argmin(healpix_cumsum < 0.9) * hp.nside2pixarea(
+            nside, degrees=True
+        )
+        return searched_area, fifty, ninety
 
     def plot_mollview(self, outpath: Path = None):
         if not hasattr(self, "fits_table"):


### PR DESCRIPTION
* Make phi coordinate 0 to 2pi. This is to be consistent with the convention in bayestar/bilby and other ligo.skymap tools.
* Log the 50/90% areas when testing