### PR TITLE
Functions for filtering out values being outside the prior in flow.py

### DIFF
--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -46,8 +46,6 @@ class FlowModel(AmplfiModel):
 
         # save our hyperparameters
         self.save_hyperparameters(ignore=["arch"])
-        # create a dictionary of prior objects for each parameter
-        self.log_prior_dict = self._get_log_prior_dict()
 
     def forward(self, context, parameters) -> Tensor:
         return -self.model.log_prob(parameters, context=context)
@@ -195,7 +193,10 @@ class FlowModel(AmplfiModel):
         )
         descaled = self.trainer.datamodule.scale(samples, reverse=True)
         parameters = self.trainer.datamodule.scale(parameters, reverse=True)
-        descaled = self.filter_descaled_parameters(descaled) # filter out samples outside of prior boundaries
+        # create a dictionary of prior objects for each parameter
+        self.log_prior_dict = self._get_log_prior_dict()
+        # filter out samples outside of prior boundaries
+        descaled = self.filter_descaled_parameters(descaled)
 
         result = self.cast_as_bilby_result(
             descaled.cpu().numpy(),

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -174,7 +174,7 @@ class FlowModel(AmplfiModel):
         discarded_count = 0
         previous_discarded_count = 0
         for idx, param in enumerate(self.inference_params):
-            prior = log_prior_dict[param]
+            prior = self.log_prior_dict[param]
             low = prior.low
             high = prior.high
             valid_idxs &= (descaled[:, idx] >= low) & (descaled[:, idx] <= high)

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -124,12 +124,10 @@ class FlowModel(AmplfiModel):
         self.test_results: list[Result] = []
         self.idx = 0
 
-    def _get_log_prior_dict(self, trainer=None):
+    def _get_log_prior_dict(self):
         """
         Get the log prior for each parameter in the model.
         """
-        if trainer is not None:
-            self.trainer = trainer
         log_prior_dict = {}
         sf = self.trainer.datamodule.waveform_sampler.parameter_sampler # need this to get the prior for some parameters
 

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -178,8 +178,8 @@ class FlowModel(AmplfiModel):
             valid_idxs &= (descaled[:, idx] >= low) & (descaled[:, idx] <= high)
             discarded_count = (~valid_idxs).sum().item()
             num_discarded += discarded_count
-            print(f"Discarded samples[{param}]: {discarded_count}")
-        print(f"Total discarded samples: {num_discarded}/{descaled.shape[0]}")
+            self._logger.info(f"Discarded samples[{param}]: {discarded_count}")
+        self._logger.info(f"Total discarded samples: {num_discarded}/{descaled.shape[0]}")
         # Filter the descaled parameters to keep only valid samples
         descaled = descaled[valid_idxs]
         return descaled


### PR DESCRIPTION
1. `_get_log_prior_dict` : Constructs a dictionary for the priors (also adds boundaries for the missing ones).
2. `filter_descaled_parameters` : Filters the descaled posteriors based on the imposed prior and prints the number of discarded values (both total and per parameter).
3. Updated `test_step` to call `filter_descaled_parameters`.
The final **descaled** posteriors will be within the prior boundaries.