### PR TITLE
`StrainVisualization` plotting callback

### DIFF
--- a/amplfi/train/callbacks.py
+++ b/amplfi/train/callbacks.py
@@ -185,18 +185,23 @@ class StrainVisualization(pl.Callback):
 
         # unpack batch
         strain, asds, parameters = batch
+        strain, asds = strain[0], asds[0]
 
         # steal some attributes needed from datamodule
         # TODO: should we link these to the pl_module?
-        highpass = self.trainer.datamodule.hparams.highpass
-        sample_rate = self.trainer.datamodule.hparams.sample_rate
-        ifos = self.trainer.datamodule.hparams.ifos
+        highpass = trainer.datamodule.hparams.highpass
+        sample_rate = trainer.datamodule.hparams.sample_rate
+        ifos = trainer.datamodule.hparams.ifos
 
         # filenames for various plots
-        whitened_td_strain_fname = self.outdir / f"{self.idx}_whitened_td.png"
-        whitened_fd_strain_fname = self.outdir / f"{self.idx}_whitened_fd.png"
-        qscan_fname = self.outdir / f"{self.idx}_qscan.png"
-        asd_fname = self.outdir / f"{self.idx}_asd.png"
+        whitened_td_strain_fname = (
+            self.outdir / f"{dataloader_idx}_whitened_td.png"
+        )
+        whitened_fd_strain_fname = (
+            self.outdir / f"{dataloader_idx}_whitened_fd.png"
+        )
+        qscan_fname = self.outdir / f"{dataloader_idx}_qscan.png"
+        asd_fname = self.outdir / f"{dataloader_idx}_asd.png"
 
         # whitened time domain strain
         plt.figure()
@@ -250,7 +255,7 @@ class StrainVisualization(pl.Callback):
         plt.close()
 
         # asds
-        frequencies = self.trainer.datamodule.frequencies.numpy()
+        frequencies = trainer.datamodule.frequencies.numpy()
         mask = frequencies > highpass
         frequencies_masked = frequencies[mask]
         plt.figure()

--- a/amplfi/train/callbacks.py
+++ b/amplfi/train/callbacks.py
@@ -1,10 +1,15 @@
 import io
 import os
 import shutil
+from pathlib import Path
 
 import h5py
 import lightning.pytorch as pl
+import matplotlib.pyplot as plt
+import numpy as np
 import s3fs
+from gwpy.plot import Plot
+from gwpy.timeseries import TimeSeries
 from lightning.pytorch.cli import SaveConfigCallback
 from lightning.pytorch.loggers import WandbLogger
 
@@ -152,3 +157,139 @@ class ModelCheckpoint(pl.callbacks.ModelCheckpoint):
     def on_train_end(self, trainer, pl_module):
         save_dir = trainer.logger.save_dir
         shutil.copy(self.best_model_path, os.path.join(save_dir, "best.ckpt"))
+
+
+class StrainVisualization(pl.Callback):
+    """
+    Lightning Callback for visualizing the strain data
+    and asds being analyzed during the test step
+    """
+
+    def __init__(self, outdir: Path, num_plot: int):
+        self.outdir = outdir
+        self.num_plot = num_plot
+
+    def on_test_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0
+    ) -> None:
+        """
+        Called at the end of each test step.
+        `outputs` consists of objects returned by `pl_module.test_step`.
+        """
+
+        # test_step returns bilby result object
+        result = outputs
+
+        if dataloader_idx >= self.num_plot:
+            return
+
+        # unpack batch
+        strain, asds, parameters = batch
+
+        # steal some attributes needed from datamodule
+        # TODO: should we link these to the pl_module?
+        highpass = self.trainer.datamodule.hparams.highpass
+        sample_rate = self.trainer.datamodule.hparams.sample_rate
+        ifos = self.trainer.datamodule.hparams.ifos
+
+        # filenames for various plots
+        whitened_td_strain_fname = self.outdir / f"{self.idx}_whitened_td.png"
+        whitened_fd_strain_fname = self.outdir / f"{self.idx}_whitened_fd.png"
+        qscan_fname = self.outdir / f"{self.idx}_qscan.png"
+        asd_fname = self.outdir / f"{self.idx}_asd.png"
+
+        # whitened time domain strain
+        plt.figure()
+        plt.title("Whitened Time Domain Strain")
+
+        for i, ifo in enumerate(ifos):
+            plt.plot(strain[i], label=ifo)
+
+        plt.legend()
+        plt.savefig(whitened_td_strain_fname)
+        plt.close()
+
+        # qscans
+        qscans = []
+
+        for i, ifo in enumerate(ifos):
+            ts = TimeSeries(
+                strain[i],
+                dt=1 / sample_rate,
+            )
+
+            spec = ts.q_transform(
+                logf=True,
+                whiten=False,
+                frange=(25, 200),
+                qrange=(4, 108),
+                outseg=(3.35, 3.6),
+            )
+            qscans.append(spec)
+
+        chirp_mass, mass_ratio = (
+            result.injection_parameters["chirp_mass"],
+            result.injection_parameters["mass_ratio"],
+        )
+        title = f"chirp_mass: {chirp_mass:2f}, mass_ratio: {mass_ratio:2f}"
+        plot = Plot(
+            *qscans,
+            figsize=(18, 5),
+            geometry=(1, 2),
+            yscale="log",
+            method="pcolormesh",
+            cmap="viridis",
+            title=title,
+        )
+
+        for i, ax in enumerate(plot.axes):
+            label = "" if i != 1 else "Normalized Energy"
+            plot.colorbar(ax=ax, label=label)
+
+        plot.savefig(qscan_fname)
+        plt.close()
+
+        # asds
+        frequencies = self.trainer.datamodule.frequencies.numpy()
+        mask = frequencies > highpass
+        frequencies_masked = frequencies[mask]
+        plt.figure()
+        for i, ifo in enumerate(ifos):
+
+            plt.loglog(frequencies_masked, asds[i], label=f"{ifo} asd")
+            plt.title("ASDs")
+            plt.xlabel("Frequency (Hz)")
+            plt.ylabel("Scaled Amplitude")
+
+        plt.legend()
+        plt.savefig(asd_fname)
+        plt.close()
+
+        # whitened frequency domain data
+        fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+        for i, ifo in enumerate(ifos):
+            strain_fft = np.fft.rfft(strain[i])
+            freqs = np.fft.rfftfreq(n=strain[i].shape[-1], d=1 / sample_rate)
+
+            axes[0].plot(
+                freqs,
+                strain_fft.real / (sample_rate ** (1 / 2)),
+                label=f"{ifo} data",
+            )
+            axes[1].plot(
+                freqs,
+                strain_fft.imag / (sample_rate ** (1 / 2)),
+                label=f"{ifo} data",
+            )
+
+        axes[0].set_title("Real")
+        axes[1].set_title("Imaginary")
+
+        axes[0].set_ylabel("Whitened Amplitude")
+        axes[0].set_xlabel("Frequency (Hz)")
+        axes[0].set_xlabel("Frequency (Hz)")
+
+        plt.legend()
+
+        plt.savefig(whitened_fd_strain_fname)
+        plt.close()

--- a/amplfi/train/data/datasets/base.py
+++ b/amplfi/train/data/datasets/base.py
@@ -165,6 +165,16 @@ class AmplfiDataset(pl.LightningDataModule):
     # ================================================ #
     # Re-parameterizing some attributes
     # ================================================ #
+
+    @property
+    def frequencies(self):
+        """
+        Frequencies corresponding to an fft
+        of a timeseries of length `kernel_length`
+        """
+        size = int(self.hparams.kernel_length * self.hparams.sample_rate)
+        return torch.fft.rfftfreq(size, d=1 / self.hparams.sample_rate)
+
     @property
     def sample_length(self):
         return (
@@ -247,7 +257,7 @@ class AmplfiDataset(pl.LightningDataModule):
             window_length,
             self.hparams.sample_rate,
             fftlength,
-            fast=self.hparams.highpass is not None,
+            fast=False,  # self.hparams.highpass is not None,
             average="median",
         )
 

--- a/amplfi/train/data/datasets/base.py
+++ b/amplfi/train/data/datasets/base.py
@@ -257,7 +257,7 @@ class AmplfiDataset(pl.LightningDataModule):
             window_length,
             self.hparams.sample_rate,
             fftlength,
-            fast=False,  # self.hparams.highpass is not None,
+            fast=self.hparams.highpass is not None,
             average="median",
         )
 

--- a/amplfi/train/models/base.py
+++ b/amplfi/train/models/base.py
@@ -2,6 +2,7 @@ import logging
 import math
 import sys
 from pathlib import Path
+from typing import Optional
 
 import lightning.pytorch as pl
 import torch
@@ -29,8 +30,9 @@ class AmplfiModel(pl.LightningModule):
     def __init__(
         self,
         inference_params: list[str],
-        outdir: Path,
+        train_outdir: Path,
         learning_rate: float,
+        test_outdir: Optional[Path] = None,
         weight_decay: float = 0.0,
         patience: int = 10,
         factor: float = 0.1,
@@ -40,8 +42,15 @@ class AmplfiModel(pl.LightningModule):
         self.scheduler_patience = patience
         self.scheduler_factor = factor
         self._logger = self.init_logging(verbose)
-        self.outdir = outdir
-        outdir.mkdir(exist_ok=True, parents=True)
+
+        if test_outdir is None:
+            test_outdir = train_outdir / "test_results"
+
+        train_outdir.mkdir(exist_ok=True)
+        test_outdir.mkdir(exist_ok=True)
+        self.test_outdir = test_outdir
+        self.train_outdir = train_outdir
+
         self.inference_params = inference_params
 
         self.save_hyperparameters()

--- a/amplfi/train/models/base.py
+++ b/amplfi/train/models/base.py
@@ -30,8 +30,8 @@ class AmplfiModel(pl.LightningModule):
     def __init__(
         self,
         inference_params: list[str],
-        train_outdir: Path,
         learning_rate: float,
+        train_outdir: Path,
         test_outdir: Optional[Path] = None,
         weight_decay: float = 0.0,
         patience: int = 10,

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -220,5 +220,7 @@ class FlowModel(AmplfiModel):
     def configure_callbacks(self):
         callbacks = []
         if self.plot_data:
-            callbacks.append(StrainVisualization(self.test_outdir))
+            callbacks.append(
+                StrainVisualization(self.test_outdir, self.num_plot)
+            )
         return callbacks

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -3,6 +3,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import torch
+from gwpy.plot import Plot
+from gwpy.timeseries import TimeSeries
 
 from ..architectures.flows import FlowArchitecture
 from ..testing import Result
@@ -33,16 +35,17 @@ class FlowModel(AmplfiModel):
         num_corner: int = 10,
         nside: int = 32,
         min_samples_per_pix: int = 15,
+        plot_data: bool = False,
         **kwargs,
     ) -> None:
 
         super().__init__(*args, **kwargs)
-        # construct our model
         self.model = arch
         self.samples_per_event = samples_per_event
         self.num_corner = num_corner
         self.nside = nside
         self.min_samples_per_pix = min_samples_per_pix
+        self.plot_data = plot_data
 
         # save our hyperparameters
         self.save_hyperparameters(ignore=["arch"])
@@ -120,13 +123,128 @@ class FlowModel(AmplfiModel):
         )
         return r
 
+    def plot(
+        self, strain: np.ndarray, asds: np.ndarray, result: bilby.result.Result
+    ):
+        """
+        Create various plots for debugging purposes
+        """
+        sample_rate = self.trainer.datamodule.hparams.sample_rate
+
+        strain_filename = self.outdir / f"{self.idx}_whitened.png"
+        spec_filename = self.outdir / f"{self.idx}_spectrogram.png"
+        asd_filename = self.outdir / f"{self.idx}_asd.png"
+        freq_data_filename = self.outdir / f"{self.idx}_whitened_frequency.png"
+
+        ifos = self.trainer.datamodule.hparams.ifos
+
+        # whitened time domain strain
+        plt.figure()
+        plt.title("Whitened Time Domain Strain")
+
+        # window data
+        # window = scipy.signal.get_window(("tukey", 0.1), strain.shape[-1])
+        # strain *= window[None]
+
+        for i, ifo in enumerate(ifos):
+            plt.plot(strain[i], label=ifo)
+
+        plt.legend()
+        plt.savefig(strain_filename)
+        plt.close()
+
+        # qscans
+        qscans = []
+
+        for i, ifo in enumerate(ifos):
+            ts = TimeSeries(
+                strain[i],
+                dt=1 / sample_rate,
+            )
+
+            spec = ts.q_transform(
+                logf=True,
+                whiten=False,
+                frange=(25, 200),
+                qrange=(4, 108),
+                outseg=(3.35, 3.6),
+            )
+            qscans.append(spec)
+
+        chirp_mass, mass_ratio = (
+            result.injection_parameters["chirp_mass"],
+            result.injection_parameters["mass_ratio"],
+        )
+        title = f"chirp_mass: {chirp_mass:2f}, mass_ratio: {mass_ratio:2f}"
+        plot = Plot(
+            *qscans,
+            figsize=(18, 5),
+            geometry=(1, 2),
+            yscale="log",
+            method="pcolormesh",
+            cmap="viridis",
+            title=title,
+        )
+
+        for i, ax in enumerate(plot.axes):
+            label = "" if i != 1 else "Normalized Energy"
+            plot.colorbar(ax=ax, label=label)
+
+        plot.savefig(spec_filename)
+        plt.close()
+
+        # asds
+        frequencies = self.trainer.datamodule.frequencies.numpy()
+        mask = frequencies > self.trainer.datamodule.hparams.highpass
+        frequencies_masked = frequencies[mask]
+        plt.figure()
+        for i, ifo in enumerate(ifos):
+
+            plt.loglog(frequencies_masked, asds[i], label=f"{ifo} asd")
+            plt.title("ASDs")
+            plt.xlabel("Frequency (Hz)")
+            plt.ylabel("Scaled Amplitude")
+
+        plt.legend()
+        plt.savefig(asd_filename)
+        plt.close()
+
+        # whitened frequency domain data
+        fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+        for i, ifo in enumerate(ifos):
+            strain_fft = np.fft.rfft(strain[i])
+            freqs = np.fft.rfftfreq(n=strain[i].shape[-1], d=1 / sample_rate)
+
+            axes[0].plot(
+                freqs,
+                strain_fft.real / (sample_rate ** (1 / 2)),
+                label=f"{ifo} data",
+            )
+            axes[1].plot(
+                freqs,
+                strain_fft.imag / (sample_rate ** (1 / 2)),
+                label=f"{ifo} data",
+            )
+
+        axes[0].set_title("Real")
+        axes[1].set_title("Imaginary")
+
+        axes[0].set_ylabel("Whitened Amplitude")
+        axes[0].set_xlabel("Frequency (Hz)")
+        axes[0].set_xlabel("Frequency (Hz)")
+
+        plt.legend()
+
+        plt.savefig(freq_data_filename)
+        plt.close()
+
     def on_test_epoch_start(self):
         self.test_results: list[Result] = []
         self.idx = 0
 
     def test_step(self, batch, _):
         strain, asds, parameters = batch
-        context = (strain, asds)
+        context = (strain, asds.clone())
 
         samples = self.model.sample(
             self.hparams.samples_per_event, context=context


### PR DESCRIPTION
Adds a lightning callback for plotting strain and asd data from the testing step. This was extremely useful for debugging some of the issues we were seeing with the MDC. 

I also added an optional `test_outdir` argument to the `pl_module` that defaults to `train_outdir / test`. This is to remove the need to constantly change the `$AMPLFI_OUTDIR` environment variable. 

Along these lines, the testing directory now gets really cluttered with plots and needs some organization. I was thinking of making either
- A subdirectory for each event (e.g. `{test_outdir}/event_0/` that contains each of the made plots
- A subdirectory for each type of plot (e.g. `{test_outdir}/skymaps/event_0.png` 

Each has its pros and cons and shouldn't matter too much in the end, but wanted your opinion @deepchatterjeeligo