### PR TITLE
Adds testing dataset for analyzing real events without injections

### DIFF
--- a/amplfi/train/callbacks.py
+++ b/amplfi/train/callbacks.py
@@ -222,17 +222,19 @@ class StrainVisualization(pl.Callback):
             spec = ts.q_transform(
                 logf=True,
                 whiten=False,
-                frange=(25, 200),
+                frange=(25, 500),
                 qrange=(4, 108),
-                outseg=(3.35, 3.6),
+                # outseg=(3, 3.7),
             )
             qscans.append(spec)
 
-        chirp_mass, mass_ratio = (
-            result.injection_parameters["chirp_mass"],
-            result.injection_parameters["mass_ratio"],
-        )
-        title = f"chirp_mass: {chirp_mass:2f}, mass_ratio: {mass_ratio:2f}"
+        title = ""
+        if result.injection_parameters is not None:
+            chirp_mass, mass_ratio = (
+                result.injection_parameters["chirp_mass"],
+                result.injection_parameters["mass_ratio"],
+            )
+            title = f"chirp_mass: {chirp_mass:2f}, mass_ratio: {mass_ratio:2f}"
         plot = Plot(
             *qscans,
             figsize=(18, 5),
@@ -293,3 +295,10 @@ class StrainVisualization(pl.Callback):
 
         plt.savefig(whitened_fd_strain_fname)
         plt.close()
+
+    def on_predict_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0
+    ):
+        return self.on_test_batch_end(
+            trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
+        )

--- a/amplfi/train/data/datasets/__init__.py
+++ b/amplfi/train/data/datasets/__init__.py
@@ -1,3 +1,7 @@
 from .flow import FlowDataset
 from .similarity import SimilarityDataset
-from .testing import ParameterTestingDataset, StrainTestingDataset
+from .testing import (
+    ParameterTestingDataset,
+    StrainTestingDataset,
+    RealEventDataset,
+)

--- a/amplfi/train/data/datasets/__init__.py
+++ b/amplfi/train/data/datasets/__init__.py
@@ -3,5 +3,5 @@ from .similarity import SimilarityDataset
 from .testing import (
     ParameterTestingDataset,
     StrainTestingDataset,
-    RealEventDataset,
+    RawStrainTestingDataset,
 )

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -29,9 +29,6 @@ def phi_from_ra(ra: np.ndarray, gpstimes: np.ndarray) -> float:
     # calculate the relative azimuthal angle in the range [0, 2pi]
     phi = np.remainder(ra - gmsts, 2 * np.pi)
 
-    # restrict to range [-pi, pi]
-    phi = np.where(phi > np.pi, phi - 2 * np.pi, phi)
-
     return phi
 
 

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -3,9 +3,8 @@ Additional Lightning DataModules for testing
 amplfi models across various usecases
 """
 
-import random
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import h5py
 import numpy as np
@@ -29,6 +28,9 @@ def phi_from_ra(ra: np.ndarray, gpstimes: np.ndarray) -> float:
     gmsts = np.array(gmsts)
     # calculate the relative azimuthal angle in the range [0, 2pi]
     phi = np.remainder(ra - gmsts, 2 * np.pi)
+
+    # restrict to range [-pi, pi]
+    phi = np.where(phi > np.pi, phi - 2 * np.pi, phi)
 
     return phi
 
@@ -223,80 +225,6 @@ class ParameterTestingDataset(FlowDataset):
         self.convert = waveform_generation_parameters is None
         self.i = 0
 
-    def background_from_gpstimes(self, gpstimes: torch.Tensor) -> torch.Tensor:
-        """
-        Find background segments corresponding to gpstimes
-        """
-
-        # load in background segments corresponding to gpstimes
-        background = []
-        segments = [
-            tuple(map(float, f.name.split(".")[0].split("-")[1:]))
-            for f in self.test_fnames
-        ]
-
-        def find_file(time: float) -> Optional[Path]:
-            """
-            Find file that contains `time`
-            """
-            for i, (start, length) in enumerate(segments):
-                in_segment = time > start + self.sample_length
-                in_segment &= time < (start + length - self.sample_length)
-                if in_segment:
-                    return self.test_fnames[i], start
-            else:
-                return None, None
-
-        # calculate seconds of data to query
-        # before and after coalescence time
-        post = self.waveform_sampler.right_pad + self.hparams.fduration / 2
-        pre = (
-            post
-            - self.hparams.kernel_length
-            - (self.hparams.fduration / 2)
-            - self.hparams.psd_length
-        )
-
-        # convert to number of indices
-        post = int(post * self.hparams.sample_rate)
-        pre = int(pre * self.hparams.sample_rate)
-
-        background = []
-        for time in gpstimes:
-            time = time.item()
-            strain = []
-
-            # find file for this gpstime
-            file, start = find_file(time)
-
-            # if none exists, use random segment
-            if file is None:
-                self._logger.info(
-                    "No segment in testing directory containing "
-                    f"{time}. Using random segment"
-                )
-                file = random.choice(self.test_fnames)
-                start, length = list(
-                    map(float, file.name.split(".")[0].split("-")[1:])
-                )
-                time = start + random.randint(
-                    self.sample_length,
-                    length - self.sample_length,
-                )
-
-            # convert from time to index in file
-            middle_idx = int((time - start) * self.hparams.sample_rate)
-            start_idx = middle_idx + pre
-            end_idx = middle_idx + post
-
-            with h5py.File(file) as f:
-                for ifo in self.hparams.ifos:
-                    strain.append(torch.tensor(f[ifo][start_idx:end_idx]))
-                strain = torch.stack(strain, dim=0)
-                background.append(strain)
-        background = torch.stack(background, dim=0)
-        return background
-
     def setup(self, stage: str):
         world_size, rank = self.get_world_size_and_rank()
         self._logger = self.get_logger(world_size, rank)
@@ -352,7 +280,9 @@ class ParameterTestingDataset(FlowDataset):
 
         self.waveforms = torch.stack([cross, plus], dim=0)
         self.parameters = torch.column_stack(params)
-        self.background = self.background_from_gpstimes(parameters["gpstime"])
+        self.background = self.background_from_gpstimes(
+            parameters["gpstime"], self.test_fnames
+        )
 
         # once we've generated validation/testing waveforms on cpu,
         # build data augmentation modules
@@ -443,3 +373,98 @@ class ParameterTestingDataset(FlowDataset):
         asds = torch.sqrt(psds)
 
         return X, asds, parameters
+
+
+class RawStrainTestingDataset(FlowDataset):
+    """
+    Testing dataset for analyzing raw strain without injections
+    from a given set of gpstimes.
+
+    Useful for testing on real events. This dataset should only be
+    used with the `predict` stage.
+
+    Subclass of `amplfi.train.data.datasets.FlowDataset` and
+    thus `amplfi.train.data.datasets.BaseDataset`. See those classes
+    for additional arguments and keyword arguments.
+
+    Args:
+        gpstimes:
+            A float, numpy array or path to an hdf5 file containing
+            the gps times of the events to analyze. If a path is
+            passed, the gps times should be stored in a dataset
+            named `gpstimes`
+    """
+
+    def __init__(
+        self, *args, gpstimes: Union[float, np.ndarray, Path], **kwargs
+    ):
+        self.gpstimes = self.parse_gps_times(gpstimes)
+        super().__init__(*args, **kwargs)
+
+    def parse_gps_times(self, gpstimes: Union[float, np.ndarray, Path]):
+        if isinstance(gpstimes, (float, int)):
+            gpstimes = np.array([gpstimes])
+        elif isinstance(gpstimes, Path):
+            with h5py.File(gpstimes, "r") as f:
+                gpstimes = f["gpstimes"][:]
+
+        return gpstimes
+
+    def setup(self, stage: str):
+        world_size, rank = self.get_world_size_and_rank()
+        self._logger = self.get_logger(world_size, rank)
+        if stage != "predict":
+            raise ValueError(
+                "RealEventDataset should only be used with `predict` stage"
+            )
+
+        self.background = self.background_from_gpstimes(
+            self.gpstimes, self.test_fnames
+        )
+
+        # once we've generated validation/testing waveforms on cpu,
+        # build data augmentation modules
+        # and transfer them to appropiate device
+        self.build_transforms(stage)
+        self.transforms_to_device()
+
+    def predict_dataloader(self) -> torch.utils.data.DataLoader:
+        dataset = torch.utils.data.TensorDataset(
+            self.background, self.gpstimes
+        )
+        dataloader = torch.utils.data.DataLoader(
+            dataset,
+            pin_memory=False,
+            num_workers=10,
+            shuffle=False,
+            batch_size=1,
+        )
+        return dataloader
+
+    def on_after_batch_transfer(self, batch, _):
+        """
+        Override of the on_after_batch_transfer hook
+        defined in `BaseDataset`.
+
+        When we're analyzing
+        real events, we don't need to do any injections
+        """
+
+        [X], gpstimes = batch
+
+        X, psds = self.psd_estimator(X)
+        X = self.whitener(X, psds)
+        psds = psds[None]
+
+        # calculate asds and highpass
+        freqs = torch.fft.rfftfreq(X.shape[-1], d=1 / self.hparams.sample_rate)
+        num_freqs = len(freqs)
+        psds = torch.nn.functional.interpolate(
+            psds, size=(num_freqs,), mode="linear"
+        )
+
+        mask = freqs > self.hparams.highpass
+        psds = psds[:, :, mask]
+        asds = torch.sqrt(psds)
+
+        return X, asds, gpstimes

--- a/amplfi/train/models/base.py
+++ b/amplfi/train/models/base.py
@@ -114,3 +114,12 @@ class AmplfiModel(pl.LightningModule):
             "optimizer": optimizer,
             "lr_scheduler": {"scheduler": scheduler, "monitor": "valid_loss"},
         }
+
+    def scale(self, parameters, reverse: bool = False):
+        """
+        Apply standard scaling to transformed parameters
+        """
+        parameters = parameters.transpose(1, 0)
+        scaled = self.scaler(parameters, reverse=reverse)
+        scaled = scaled.transpose(1, 0)
+        return scaled

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -145,6 +145,7 @@ class FlowModel(AmplfiModel):
         skymap_filename = self.test_outdir / f"{gpstime.item()}_mollview.png"
         corner_filename = self.test_outdir / f"{gpstime.item()}_corner.png"
         fits_filename = self.test_outdir / f"{gpstime.item()}.fits"
+        result_filename = self.test_outdir / f"{gpstime.item()}_result.hdf5"
         result.plot_corner(
             save=True,
             filename=corner_filename,
@@ -154,6 +155,7 @@ class FlowModel(AmplfiModel):
             outpath=skymap_filename,
         )
         result.fits_table.writeto(fits_filename, overwrite=True)
+        result.save_to_file(result_filename, extension="hdf5")
         return result
 
     def on_test_epoch_start(self):

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -3,13 +3,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import torch
-from gwpy.plot import Plot
-from gwpy.timeseries import TimeSeries
 
 from ..architectures.flows import FlowArchitecture
 from ..callbacks import StrainVisualization
 from ..testing import Result
 from .base import AmplfiModel
+from typing import Optional
 
 Tensor = torch.Tensor
 
@@ -93,213 +92,16 @@ class FlowModel(AmplfiModel):
         )
         return loss
 
-    def cast_as_bilby_result(
-        self,
-        samples: np.ndarray,
-        truth: np.ndarray,
-    ):
-        """Cast posterior samples as Bilby Result object
-        for ease of producing corner and pp plots
-
-        Args:
-            samples: posterior samples (1, num_samples, num_params)
-            truth: true values of the parameters  (1, num_params)
-            priors: dictionary of prior objects
-            label: label for the bilby result object
-
-        """
-
-        injection_parameters = {
-            k: float(v) for k, v in zip(self.inference_params, truth)
-        }
-
-        # create dummy prior with correct attributes
-        # for making our results compatible with bilbys make_pp_plot
-        priors = {
-            param: bilby.core.prior.base.Prior(latex_label=param)
-            for param in self.inference_params
-        }
-        posterior = {}
-        for idx, k in enumerate(self.inference_params):
-            posterior[k] = samples.T[idx].flatten()
-        posterior = pd.DataFrame(posterior)
-
-        r = Result(
-            label="PEModel",
-            injection_parameters=injection_parameters,
-            posterior=posterior,
-            search_parameter_keys=self.inference_params,
-            priors=priors,
-        )
-        return r
-
-    def plot(
-        self, strain: np.ndarray, asds: np.ndarray, result: bilby.result.Result
-    ):
-        """
-        Create various plots for debugging purposes
-        """
-        sample_rate = self.trainer.datamodule.hparams.sample_rate
-
-        strain_filename = self.outdir / f"{self.idx}_whitened.png"
-        spec_filename = self.outdir / f"{self.idx}_spectrogram.png"
-        asd_filename = self.outdir / f"{self.idx}_asd.png"
-        freq_data_filename = self.outdir / f"{self.idx}_whitened_frequency.png"
-
-        ifos = self.trainer.datamodule.hparams.ifos
-
-        # whitened time domain strain
-        plt.figure()
-        plt.title("Whitened Time Domain Strain")
-
-        for i, ifo in enumerate(ifos):
-            plt.plot(strain[i], label=ifo)
-
-        plt.legend()
-        plt.savefig(strain_filename)
-        plt.close()
-
-        # qscans
-        qscans = []
-
-        for i in range(len(ifos)):
-            ts = TimeSeries(
-                strain[i],
-                dt=1 / sample_rate,
-            )
-
-            spec = ts.q_transform(
-                logf=True,
-                whiten=False,
-                frange=(25, 200),
-                qrange=(4, 108),
-                outseg=(3.35, 3.6),
-            )
-            qscans.append(spec)
-
-        chirp_mass, mass_ratio = (
-            result.injection_parameters["chirp_mass"],
-            result.injection_parameters["mass_ratio"],
-        )
-        title = f"chirp_mass: {chirp_mass:2f}, mass_ratio: {mass_ratio:2f}"
-        plot = Plot(
-            *qscans,
-            figsize=(18, 5),
-            geometry=(1, 2),
-            yscale="log",
-            method="pcolormesh",
-            cmap="viridis",
-            title=title,
-        )
-
-        for i, ax in enumerate(plot.axes):
-            label = "" if i != 1 else "Normalized Energy"
-            plot.colorbar(ax=ax, label=label)
-
-        plot.savefig(spec_filename)
-        plt.close()
-
-        # asds
-        frequencies = self.trainer.datamodule.frequencies.numpy()
-        mask = frequencies > self.trainer.datamodule.hparams.highpass
-        frequencies_masked = frequencies[mask]
-        plt.figure()
-        for i, ifo in enumerate(ifos):
-            plt.loglog(frequencies_masked, asds[i], label=f"{ifo} asd")
-            plt.title("ASDs")
-            plt.xlabel("Frequency (Hz)")
-            plt.ylabel("Scaled Amplitude")
-
-        plt.legend()
-        plt.savefig(asd_filename)
-        plt.close()
-
-        # whitened frequency domain data
-        fig, axes = plt.subplots(1, 2, figsize=(14, 6))
-        for i, ifo in enumerate(ifos):
-            strain_fft = np.fft.rfft(strain[i])
-            freqs = np.fft.rfftfreq(n=strain[i].shape[-1], d=1 / sample_rate)
-
-            axes[0].plot(
-                freqs,
-                strain_fft.real / (sample_rate ** (1 / 2)),
-                label=f"{ifo} data",
-            )
-            axes[1].plot(
-                freqs,
-                strain_fft.imag / (sample_rate ** (1 / 2)),
-                label=f"{ifo} data",
-            )
-
-        axes[0].set_title("Real")
-        axes[1].set_title("Imaginary")
-
-        axes[0].set_ylabel("Whitened Amplitude")
-        axes[0].set_xlabel("Frequency (Hz)")
-        axes[0].set_xlabel("Frequency (Hz)")
-
-        plt.legend()
-
-        plt.savefig(freq_data_filename)
-        plt.close()
-
-    def on_test_epoch_start(self):
-        self.test_results: list[Result] = []
-        self.idx = 0
-
-    def filter_parameters(self, parameters: torch.Tensor):
-        """
-        Filter the descaled parameters to keep only valid samples
-        within their boundaries.
-
-        Args:
-            descaled (torch.Tensor): The descaled parameters tensor.
-
-        Returns:
-            torch.Tensor: The filtered descaled parameters.
-        """
-        net_mask = torch.ones(
-            parameters.shape[0], dtype=bool, device=parameters.device
-        )
-        waveform_sampler = self.trainer.datamodule.waveform_sampler
-        priors = waveform_sampler.parameter_sampler.parameters
-        for i, param in enumerate(self.inference_params):
-            samples = parameters[:, i]
-            if param in ["dec", "phi", "psi"]:
-                prior = getattr(
-                    self.trainer.datamodule.waveform_sampler, param
-                )
-            else:
-                prior = priors[param]
-
-            mask = (prior.log_prob(samples) == float("-inf")).to(
-                samples.device
-            )
-            self._logger.debug(
-                f"Removed {mask.sum()}/{len(mask)} samples for parameter "
-                f"{param} outside of prior range"
-            )
-
-            net_mask &= ~mask
-
-        self._logger.info(
-            f"Removed {(~net_mask).sum()}/{len(net_mask)} total samples "
-            "outside of prior range"
-        )
-        parameters = parameters[net_mask]
-
-        return parameters
-
     def test_step(self, batch, _) -> bilby.result.Result:
         strain, asds, parameters = batch
-        context = (strain, asds.clone())
+        context = (strain, asds)
 
         samples = self.model.sample(
             self.hparams.samples_per_event, context=context
         )
-        descaled = self.trainer.datamodule.scale(samples, reverse=True)
+        descaled = self.scale(samples, reverse=True)
         descaled = self.filter_parameters(descaled)
-        parameters = self.trainer.datamodule.scale(parameters, reverse=True)
+        parameters = self.scale(parameters, reverse=True)
 
         result = self.cast_as_bilby_result(
             descaled.cpu().numpy(),
@@ -325,6 +127,38 @@ class FlowModel(AmplfiModel):
         self.idx += 1
 
         return result
+
+    def predict_step(self, batch, _):
+        strain, asds, gpstime = batch
+        context = (strain, asds)
+
+        samples = self.model.sample(
+            self.hparams.samples_per_event, context=context
+        )
+        descaled = self.scale(samples, reverse=True)
+        descaled = self.filter_parameters(descaled)
+        result = self.cast_as_bilby_result(
+            descaled.cpu().numpy(),
+            None,
+        )
+        result.calculate_skymap(self.nside, self.min_samples_per_pix)
+        skymap_filename = self.test_outdir / f"{gpstime.item()}_mollview.png"
+        corner_filename = self.test_outdir / f"{gpstime.item()}_corner.png"
+        fits_filename = self.test_outdir / f"{gpstime.item()}.fits"
+        result.plot_corner(
+            save=True,
+            filename=corner_filename,
+            levels=(0.5, 0.9),
+        )
+        result.plot_mollview(
+            outpath=skymap_filename,
+        )
+        result.fits_table.writeto(fits_filename, overwrite=True)
+        return result
+
+    def on_test_epoch_start(self):
+        self.test_results: list[Result] = []
+        self.idx = 0
 
     def on_test_epoch_end(self):
         # pp plot
@@ -371,6 +205,89 @@ class FlowModel(AmplfiModel):
         plt.xlabel("Sq. deg.")
         plt.legend()
         plt.savefig(self.test_outdir / "fifty_ninety_areas.png")
+
+    def cast_as_bilby_result(
+        self,
+        samples: np.ndarray,
+        truth: Optional[np.ndarray] = None,
+    ):
+        """Cast posterior samples as Bilby Result object
+        for ease of producing corner and pp plots
+
+        Args:
+            samples: posterior samples (1, num_samples, num_params)
+            truth: true values of the parameters  (1, num_params)
+
+        """
+
+        injection_parameters = (
+            {k: float(v) for k, v in zip(self.inference_params, truth)}
+            if truth is not None
+            else None
+        )
+
+        # create dummy prior with correct attributes
+        # for making our results compatible with bilbys make_pp_plot
+        priors = {
+            param: bilby.core.prior.base.Prior(latex_label=param)
+            for param in self.inference_params
+        }
+        posterior = {}
+        for idx, k in enumerate(self.inference_params):
+            posterior[k] = samples.T[idx].flatten()
+        posterior = pd.DataFrame(posterior)
+
+        r = Result(
+            label="PEModel",
+            injection_parameters=injection_parameters,
+            posterior=posterior,
+            search_parameter_keys=self.inference_params,
+            priors=priors,
+        )
+        return r
+
+    def filter_parameters(self, parameters: torch.Tensor):
+        """
+        Filter the descaled parameters to keep only valid samples
+        within their boundaries.
+
+        Args:
+            descaled (torch.Tensor): The descaled parameters tensor.
+
+        Returns:
+            torch.Tensor: The filtered descaled parameters.
+        """
+        net_mask = torch.ones(
+            parameters.shape[0], dtype=bool, device=parameters.device
+        )
+        waveform_sampler = self.trainer.datamodule.waveform_sampler
+        priors = waveform_sampler.parameter_sampler.parameters
+        for i, param in enumerate(self.inference_params):
+            samples = parameters[:, i]
+            if param in ["dec", "phi", "psi"]:
+                prior = getattr(
+                    self.trainer.datamodule.waveform_sampler, param
+                )
+            else:
+                prior = priors[param]
+
+            mask = (prior.log_prob(samples) == float("-inf")).to(
+                samples.device
+            )
+            self._logger.debug(
+                f"Removed {mask.sum()}/{len(mask)} samples for parameter "
+                f"{param} outside of prior range"
+            )
+
+            net_mask &= ~mask
+
+        self._logger.info(
+            f"Removed {(~net_mask).sum()}/{len(net_mask)} total samples "
+            "outside of prior range"
+        )
+        parameters = parameters[net_mask]
+
+        return parameters
 
     def configure_callbacks(self):
         callbacks = []

--- a/amplfi/train/testing.py
+++ b/amplfi/train/testing.py
@@ -27,7 +27,8 @@ def get_sky_projection(ra, dec, dist, nside=32, min_samples_per_pix=15):
     """
     theta = np.pi / 2 - dec
     # mask out non physical samples;
-    mask = (ra > 0) * (ra < 2 * np.pi)
+    # mask = (ra > 0) * (ra < 2 * np.pi)
+    mask = (ra > -np.pi) * (ra < np.pi)
     mask &= (theta > 0) * (theta < np.pi)
 
     ra = ra[mask]
@@ -128,16 +129,22 @@ class Result(bilby.result.Result):
     def plot_mollview(self, outpath: Path = None):
         if not hasattr(self, "fits_table"):
             raise RuntimeError("Call calculate_skymap before plotting")
+
         healpix = self.fits_table.data["PROBDENSITY"]
-        ra_inj = self.injection_parameters["phi"]
-        dec_inj = self.injection_parameters["dec"]
-        theta_inj = np.pi / 2 - dec_inj
-        plt.close()
+
         # plot molleweide
+        plt.close()
         fig = hp.mollview(healpix, nest=True)
-        hp.visufunc.projscatter(
-            theta_inj, ra_inj, marker="x", color="red", s=150
-        )
+
+        # plot true values if available
+        if self.injection_parameters is not None:
+            ra_inj = self.injection_parameters["phi"]
+            dec_inj = self.injection_parameters["dec"]
+            theta_inj = np.pi / 2 - dec_inj
+
+            hp.visufunc.projscatter(
+                theta_inj, ra_inj, marker="x", color="red", s=150
+            )
 
         plt.savefig(outpath)
 

--- a/amplfi/train/testing.py
+++ b/amplfi/train/testing.py
@@ -27,8 +27,7 @@ def get_sky_projection(ra, dec, dist, nside=32, min_samples_per_pix=15):
     """
     theta = np.pi / 2 - dec
     # mask out non physical samples;
-    # mask = (ra > 0) * (ra < 2 * np.pi)
-    mask = (ra > -np.pi) * (ra < np.pi)
+    mask = (ra > 0) * (ra < 2 * np.pi)
     mask &= (theta > 0) * (theta < np.pi)
 
     ra = ra[mask]


### PR DESCRIPTION
- Adds a testing dataset that, given a list or file with gpstimes, can find the corresponding raw strain segments from the background files in the background directory for analysis - useful for analyzing real events.
- When testing, the scaler is no longe refit