### PR TITLE
Parallellize distance ansatz calculation

### DIFF
--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -1,7 +1,7 @@
 import bilby
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
+import pandas as pd  # noqa: F401
 import torch
 from gwpy.plot import Plot
 from gwpy.timeseries import TimeSeries
@@ -95,8 +95,8 @@ class FlowModel(AmplfiModel):
 
     def cast_as_bilby_result(
         self,
-        samples: np.ndarray,
-        truth: np.ndarray,
+        samples: torch.Tensor,
+        truth: torch.Tensor,
     ):
         """Cast posterior samples as Bilby Result object
         for ease of producing corner and pp plots
@@ -122,7 +122,8 @@ class FlowModel(AmplfiModel):
         posterior = {}
         for idx, k in enumerate(self.inference_params):
             posterior[k] = samples.T[idx].flatten()
-        posterior = pd.DataFrame(posterior)
+
+        # posterior = pd.DataFrame(posterior)
 
         r = Result(
             label="PEModel",
@@ -300,10 +301,9 @@ class FlowModel(AmplfiModel):
         descaled = self.trainer.datamodule.scale(samples, reverse=True)
         descaled = self.filter_parameters(descaled)
         parameters = self.trainer.datamodule.scale(parameters, reverse=True)
-
         result = self.cast_as_bilby_result(
-            descaled.cpu().numpy(),
-            parameters.cpu().numpy()[0],
+            descaled,
+            parameters[0],
         )
         result.calculate_skymap(self.nside, self.min_samples_per_pix)
         self.test_results.append(result)

--- a/amplfi/train/testing.py
+++ b/amplfi/train/testing.py
@@ -3,15 +3,67 @@ from pathlib import Path
 import bilby
 import healpy as hp
 import matplotlib.pyplot as plt
-import numpy as np
+import torch
 from astropy import io, table
 from astropy import units as u
+from ml4gw.constants import PI
 
 from . import distance
+
+max_nside = 1 << 29
 
 
 def nest2uniq(nside, ipix):
     return 4 * nside * nside + ipix
+
+
+def nside2npix(nside):
+    return 12 * nside * nside
+
+
+def nside2pixarea(nside, degrees=True):
+    pixarea = 4 * PI / nside2npix(nside)
+
+    if degrees:
+        pixarea = pixarea * (180.0 / PI) ** 2
+
+    return pixarea
+
+
+def isnsideok(nside, nest=False):
+    if hasattr(nside, "__len__"):
+        if not isinstance(nside, torch.Tensor):
+            nside = torch.asarray(nside)
+        is_nside_ok = (
+            (nside == nside.int()) & (nside > 0) & (nside <= max_nside)
+        )
+        if nest:
+            is_nside_ok &= nside.int() & (nside.int() - 1 == 0)
+    else:
+        is_nside_ok = (nside == int(nside)) and (0 < nside <= max_nside)
+        if nest:
+            is_nside_ok = is_nside_ok and (int(nside) & (int(nside) - 1)) == 0
+    return is_nside_ok
+
+
+def check_nside(nside, nest=False):
+    """Raises exception if nside is not valid"""
+    if not torch.all(isnsideok(nside, nest=nest)):
+        raise ValueError(
+            f"{nside} is not a valid nside parameter (must be a power of 2,\
+                less than 2**30)"
+        )
+
+
+def lonlat2thetaphi(lon, lat):
+    return PI / 2.0 - torch.deg2rad(lat), torch.deg2rad(lon)
+
+
+def check_theta_valid(theta):
+    """Raises exception if theta is not within 0 and pi"""
+    theta = torch.asarray(theta)
+    if not ((theta >= 0).all() and (theta <= PI + 1e-5).all()):
+        raise ValueError("THETA is out of range [0,pi]")
 
 
 def get_sky_projection(ra, dec, dist, nside=32, min_samples_per_pix=15):
@@ -25,10 +77,10 @@ def get_sky_projection(ra, dec, dist, nside=32, min_samples_per_pix=15):
         nside: nside parameter for HEALPix
         min_samples_per_pix: minimum # samples per pixel for distance ansatz
     """
-    theta = np.pi / 2 - dec
+    theta = PI / 2 - dec
     # mask out non physical samples;
-    mask = (ra > 0) * (ra < 2 * np.pi)
-    mask &= (theta > 0) * (theta < np.pi)
+    mask = (ra > 0) * (ra < 2 * PI)
+    mask &= (theta > 0) * (theta < PI)
 
     ra = ra[mask]
     dec = dec[mask]
@@ -104,7 +156,7 @@ class Result(bilby.result.Result):
 
         ra_inj = self.injection_parameters["phi"]
         dec_inj = self.injection_parameters["dec"]
-        theta_inj = np.pi / 2 - dec_inj
+        theta_inj = PI / 2 - dec_inj
         true_ipix = hp.ang2pix(nside, theta_inj, ra_inj, nest=True)
 
         sorted_idxs = np.argsort(healpix)[
@@ -131,7 +183,7 @@ class Result(bilby.result.Result):
         healpix = self.fits_table.data["PROBDENSITY"]
         ra_inj = self.injection_parameters["phi"]
         dec_inj = self.injection_parameters["dec"]
-        theta_inj = np.pi / 2 - dec_inj
+        theta_inj = PI / 2 - dec_inj
         plt.close()
         # plot molleweide
         fig = hp.mollview(healpix, nest=True)


### PR DESCRIPTION
This implements a parallelized root solver function to solve for the distance `ansatz` for all pixels at once.

However, this implementation is ~2x slower than the original `scipy` implementation.