### PR TITLE
Refactor saving posteriors to optional callback

### DIFF
--- a/amplfi/data/tasks.py
+++ b/amplfi/data/tasks.py
@@ -96,7 +96,7 @@ class LigoSkymap(
 
     def output(self):
         event_dir = self.branch_data.parent
-        return law.LocalFileTarget(event_dir / "skymap.flattened.fits")
+        return law.LocalFileTarget(event_dir / "skymap.fits")
 
     def run(self):
         from ligo.skymap.tool import (

--- a/amplfi/train/callbacks.py
+++ b/amplfi/train/callbacks.py
@@ -327,9 +327,6 @@ class SavePosteriors(pl.Callback):
         # test_step returns bilby result object
         result = outputs
 
-        if batch_idx >= self.num_plot:
-            return
-
         outdir = self.outdir / f"event_{batch_idx}"
         outdir.mkdir(exist_ok=True)
 

--- a/amplfi/train/callbacks.py
+++ b/amplfi/train/callbacks.py
@@ -307,7 +307,7 @@ class StrainVisualization(pl.Callback):
         )
 
 
-class SavePosteriors(pl.Callback):
+class SavePosterior(pl.Callback):
     """
     Lightning Callback for bilby result objects and
     posterior data to disk

--- a/amplfi/train/callbacks.py
+++ b/amplfi/train/callbacks.py
@@ -305,3 +305,43 @@ class StrainVisualization(pl.Callback):
         return self.on_test_batch_end(
             trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
         )
+
+
+class SavePosteriors(pl.Callback):
+    """
+    Lightning Callback for bilby result objects and
+    posterior data to disk
+    """
+
+    def __init__(self, outdir: Path):
+        self.outdir = outdir
+
+    def on_test_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0
+    ) -> None:
+        """
+        Called at the end of each test step.
+        `outputs` consists of objects returned by `pl_module.test_step`.
+        """
+
+        # test_step returns bilby result object
+        result = outputs
+
+        if batch_idx >= self.num_plot:
+            return
+
+        outdir = self.outdir / f"event_{batch_idx}"
+        outdir.mkdir(exist_ok=True)
+
+        # save posterior samples for ease of use with
+        # ligo skymap and save full result to have
+        # access to the true injection parameters
+        result.save_posterior_samples(outdir / "posterior_samples.dat")
+        result.save_to_file(outdir / "result.hdf5", extension="hdf5")
+
+    def on_predict_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0
+    ):
+        return self.on_test_batch_end(
+            trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
+        )

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -116,11 +116,6 @@ class FlowModel(AmplfiModel):
         # add ra column for use with ligo-skymap-from-samples
         result.posterior["ra"] = result.posterior["phi"]
 
-        # save posterior samples for ease of use with
-        # ligo skymap and save full result to have
-        # access to the true injection parameters
-        result.save_posterior_samples(test_outdir / "posterior_samples.dat")
-        result.save_to_file(test_outdir / "result.hdf5", extension="hdf5")
         self.test_results.append(result)
 
         # plot corner and skymap


### PR DESCRIPTION
- Fixes bug in LigoSkymap task output name
- Makes saving posteriors an optional callback since this step can be slow, and users may not necessarily need posteriors for every event (say, if just making a PP-plot)