### PR TITLE
Add gradient tracking callback

### DIFF
--- a/amplfi/train/callbacks.py
+++ b/amplfi/train/callbacks.py
@@ -344,6 +344,7 @@ class SavePosterior(pl.Callback):
             trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
         )
 
+
 class GradientTracker(pl.Callback):
     def __init__(self, norm_type: int = 2):
         self.norm_type = norm_type


### PR DESCRIPTION
Adding callback to monitor gradient magnitudes to help debug issues like this one https://wandb.ai/ml4gw/amplfi/runs/ag20vpx9?nw=nwuserethanmarx where there was a huge spike in training and validatoin loss.

Likely due to a bad batch, but would be good to be robust to this by adding in gradient clipping