### PR TITLE
Change default scheduler to `OneCycle` and add `SaveWandbUrl` callback

### DIFF
--- a/amplfi/train/configs/flow/cbc.yaml
+++ b/amplfi/train/configs/flow/cbc.yaml
@@ -31,7 +31,6 @@ trainer:
 model:
   class_path: amplfi.train.models.flow.FlowModel
   init_args:
-    optimizer:
     train_outdir: ${oc.env:AMPLFI_OUTDIR}
     nside: 32
     min_samples_per_pix: 15

--- a/amplfi/train/configs/flow/cbc.yaml
+++ b/amplfi/train/configs/flow/cbc.yaml
@@ -13,7 +13,7 @@ trainer:
         project: amplfi
         # uncomment and set to name your run
         # name: my-amplfi-run 
-  max_epochs: 400
+  max_epochs: 800
   check_val_every_n_epoch: 1
   log_every_n_steps: 50
   benchmark: false
@@ -31,6 +31,7 @@ trainer:
 model:
   class_path: amplfi.train.models.flow.FlowModel
   init_args:
+    optimizer:
     train_outdir: ${oc.env:AMPLFI_OUTDIR}
     nside: 32
     min_samples_per_pix: 15
@@ -58,8 +59,8 @@ model:
               class_path: ml4gw.nn.norm.GroupNorm1DGetter
               init_args:
                 groups: 8
-    patience: 40
     learning_rate: 0.00071444
+    pct_start: 0.1
     weight_decay: 0.00042
 data:
   class_path: amplfi.train.data.datasets.FlowDataset

--- a/amplfi/train/configs/flow/sg.yaml
+++ b/amplfi/train/configs/flow/sg.yaml
@@ -12,7 +12,7 @@ trainer:
         project: amplfi
         # uncomment and set to name your run
         # name: 
-  max_epochs: 200
+  max_epochs: 800
   check_val_every_n_epoch: 1
   log_every_n_steps: 20
   benchmark: false
@@ -53,9 +53,9 @@ model:
               class_path: ml4gw.nn.norm.GroupNorm1DGetter
               init_args:
                 groups: 16
-    patience: 10
     factor: 0.1
     learning_rate: 3.77e-4
+    pct_start: 0.1
     weight_decay: 0.0
 data:
   class_path: amplfi.train.data.datasets.FlowDataset

--- a/amplfi/train/configs/similarity/cbc.yaml
+++ b/amplfi/train/configs/similarity/cbc.yaml
@@ -12,7 +12,7 @@ trainer:
         project: amplfi
         # uncomment and set to name your run
         # name: my-amplfi-run 
-  max_epochs: 400
+  max_epochs: 800
   check_val_every_n_epoch: 1
   log_every_n_steps: 50
   benchmark: false
@@ -54,9 +54,9 @@ model:
               init_args:
                 groups: 8
         expander_factor: 3
-    patience: 5
     learning_rate: 0.00071444
-    weight_decay: 0.0
+    pct_start: 0.1
+    weight_decay: 0.0042
 data:
   class_path: amplfi.train.data.datasets.SimilarityDataset
   init_args:

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -272,7 +272,8 @@ class FlowModel(AmplfiModel):
         return parameters
 
     def configure_callbacks(self):
-        callbacks = [ProbProbPlot()]
+        callbacks = super().configure_callbacks()
+        callbacks += [ProbProbPlot()]
         if self.plot_data:
             callbacks.append(
                 StrainVisualization(self.test_outdir, self.num_plot)

--- a/amplfi/train/models/flow.py
+++ b/amplfi/train/models/flow.py
@@ -129,10 +129,6 @@ class FlowModel(AmplfiModel):
 
         test_outdir = self.test_outdir / f"event_{batch_idx}"
         test_outdir.mkdir(parents=True, exist_ok=True)
-
-        # add ra column for use with ligo-skymap-from-samples
-        result.posterior["ra"] = result.posterior["phi"]
-
         self.test_results.append(result)
 
         # plot corner and skymap
@@ -226,6 +222,8 @@ class FlowModel(AmplfiModel):
             search_parameter_keys=self.inference_params,
             priors=priors,
         )
+        r.posterior["ra"] = r.posterior["phi"]
+        r.injection_parameters["ra"] = r.injection_parameters["phi"]
         return r
 
     def filter_parameters(self, parameters: torch.Tensor):

--- a/amplfi/utils/result.py
+++ b/amplfi/utils/result.py
@@ -26,7 +26,10 @@ class AmplfiResult(bilby.result.Result):
     ) -> CrossmatchResult:
         """
         Calculate a `ligo.skymap.postprocess.crossmatch.CrossmatchResult`
-        based on sky localization and distance posterior samples
+        based on sky localization and distance posterior samples.
+        The posterior dataframe and injection_parameters dict
+        should have `ra` and `dec` entries
+
         """
         skymap = self.to_skymap(
             nside=nside,
@@ -35,7 +38,7 @@ class AmplfiResult(bilby.result.Result):
         )
 
         coordinates = SkyCoord(
-            self.injection_parameters["phi"] * u.rad,
+            self.injection_parameters["ra"] * u.rad,
             self.injection_parameters["dec"] * u.rad,
             distance=self.injection_parameters["distance"] * u.Mpc,
         )
@@ -47,13 +50,17 @@ class AmplfiResult(bilby.result.Result):
         min_samples_per_pix: int = 15,
         use_distance: bool = True,
     ) -> Table:
-        """Calculate a histogram skymap from posterior samples"""
+        """
+        Calculate a histogram skymap from posterior samples
+        The posterior dataframe and injection_parameters dict
+           should have `ra` and `dec` entries
+        """
         distance = None
         if use_distance:
             distance = self.posterior["distance"]
 
         return skymap.histogram_skymap(
-            self.posterior["phi"],
+            self.posterior["ra"],
             self.posterior["dec"],
             distance,
             nside=nside,
@@ -65,13 +72,15 @@ class AmplfiResult(bilby.result.Result):
     ) -> tuple[float, float, float]:
         """
         Calculate the searched area, and estimates
-        of 50% and 90% credible region
+        of 50% and 90% credible region.
+        The posterior dataframe and injection_parameters dict
+        should have `ra` and `dec` entries
         """
-        skymap = self.to_skymap(nside)["PROBDENSITY"]
+        smap = self.to_skymap(nside)["PROBDENSITY"]
 
         return skymap.calculate_searched_area(
-            skymap,
-            self.injection_parameters["phi"],
+            smap,
+            self.injection_parameters["ra"],
             self.injection_parameters["dec"],
             nside=nside,
         )
@@ -80,7 +89,9 @@ class AmplfiResult(bilby.result.Result):
         self, nside: int = 32, outpath: Optional[Path] = None
     ) -> plt.Figure:
         """
-        Plot a mollweide projection of the skymap
+        Plot a mollweide projection of the skymap.
+        The posterior dataframe and injection_parameters dict
+        should have `ra` and `dec` entries
         """
         skymap = self.to_skymap(nside)["PROBDENSITY"]
 


### PR DESCRIPTION
- Adds callback for saving the wandb url to disk for later use
- Changes default optimizer to OneCycle which should improved results compared with Plateau
- Creates skymap in amplfi result object using `posterior["ra"]`