### PR TITLE
Explicitly seed dataloader

### DIFF
--- a/amplfi/train/cli/base.py
+++ b/amplfi/train/cli/base.py
@@ -42,3 +42,9 @@ class AmplfiBaseCLI(LightningCLI):
             "model.init_args.inference_params",
             apply_on="parse",
         )
+
+        parser.link_arguments(
+            "seed_everything",
+            "data.init_args.seed",
+            apply_on="parse",
+        )

--- a/amplfi/train/data/datasets/base.py
+++ b/amplfi/train/data/datasets/base.py
@@ -92,8 +92,14 @@ class AmplfiDataset(pl.LightningDataModule):
         num_files_per_batch: Optional[int] = None,
         max_num_workers: int = 6,
         verbose: bool = False,
+        seed: Optional[int] = None,
     ):
         super().__init__()
+        # TODO: we shouldn't have to do this, since
+        # lightning calls this in the `trainer`, but
+        # I found that our testing parameters were different
+        # even when using the same seed
+        pl.seed_everything(seed)
         self.save_hyperparameters(ignore=["waveform_sampler"])
         self.init_logging(verbose)
         self.waveform_sampler = waveform_sampler


### PR DESCRIPTION
When trying to compare testing runs using random sampling from our testing distribution, I was seeing discrepancies between different runs on different machines, even when using the same seed. 

Adding a `pl.seed_everything` directly in the dataloader init seemed to solve this. Lightning does call this in the main thread, but for some reason its not propagating to the dataloader `torch.distribution.sample` calls. 
At some point we should identify why, but for now this is a hotfix that should work.  

