### PR TITLE
Save all parameters 

### DIFF
--- a/amplfi/train/data/datasets/base.py
+++ b/amplfi/train/data/datasets/base.py
@@ -357,8 +357,9 @@ class AmplfiDataset(pl.LightningDataModule):
                 if k in parameters.keys():
                     params.append(torch.Tensor(parameters[k]))
 
+            self.test_inference_params = torch.column_stack(params)
+            self.test_parameters: dict[str, torch.tensor] = parameters
             self.test_waveforms = torch.stack([cross, plus], dim=0)
-            self.test_parameters = torch.column_stack(params)
 
         # once we've generated validation/testing waveforms on cpu,
         # build data augmentation modules
@@ -503,7 +504,7 @@ class AmplfiDataset(pl.LightningDataModule):
         # build waveform dataloader
         cross, plus = self.test_waveforms
         waveform_dataset = torch.utils.data.TensorDataset(
-            cross, plus, self.test_parameters
+            cross, plus, self.test_inference_params
         )
         waveform_dataloader = torch.utils.data.DataLoader(
             waveform_dataset,

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -121,14 +121,14 @@ class StrainTestingDataset(FlowDataset):
         self.build_transforms(stage)
         self.transforms_to_device()
 
-        self.test_parameters = parameters
+        self.test_inference_params = parameters
         self.test_strain = strain
 
     def test_dataloader(self) -> torch.utils.data.DataLoader:
         # build dataset and dataloader that will
         # simply load one injection (and its parameters) at a time
         dataset = torch.utils.data.TensorDataset(
-            self.test_strain, self.test_parameters
+            self.test_strain, self.test_inference_params
         )
 
         return torch.utils.data.DataLoader(

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -44,13 +44,12 @@ class StrainTestingDataset(FlowDataset):
             Path to hdf5 file containing premade injections.
             For each interferometer being analyzed, the strain
             data should be stored in an hdf5 dataset named
-            after that interferometer.The dataset should be
+            after that interferometer. The dataset should be
             of shape (batch, time). It is assumed that the coalescence
             time of the injection is placed in the middle of each sample
-            of the array. In addition, the parameters used to generate
-            each injection should live in a dataset named after the
-            parameter, e.g. `chirp_mass`.
-
+            of the array. In addition, each inference parameter
+            should be stored in a dataset with the same name as the
+            parameter, e.g. `chirp_mass`, `mass_ratio`, etc.
 
     """
 
@@ -122,13 +121,15 @@ class StrainTestingDataset(FlowDataset):
         self.build_transforms(stage)
         self.transforms_to_device()
 
-        self.parameters = parameters
-        self.strain = strain
+        self.test_parameters = parameters
+        self.test_strain = strain
 
     def test_dataloader(self) -> torch.utils.data.DataLoader:
         # build dataset and dataloader that will
         # simply load one injection (and its parameters) at a time
-        dataset = torch.utils.data.TensorDataset(self.strain, self.parameters)
+        dataset = torch.utils.data.TensorDataset(
+            self.test_strain, self.test_parameters
+        )
 
         return torch.utils.data.DataLoader(
             dataset, batch_size=1, num_workers=12, shuffle=False
@@ -242,7 +243,7 @@ class ParameterTestingDataset(FlowDataset):
                     continue
 
                 parameters[parameter] = torch.tensor(
-                    f[parameter][:], dtype=torch.float32
+                    f[parameter], dtype=torch.float32
                 )
 
         # apply conversion function to parameters

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -279,7 +279,7 @@ class ParameterTestingDataset(FlowDataset):
         self.waveforms = torch.stack([cross, plus], dim=0)
         self.parameters = torch.column_stack(params)
         self.background = self.background_from_gpstimes(
-            parameters["gpstime"] - 98304000, self.test_fnames
+            parameters["gpstime"], self.test_fnames
         )
 
         # once we've generated validation/testing waveforms on cpu,

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -242,7 +242,7 @@ class ParameterTestingDataset(FlowDataset):
                     continue
 
                 parameters[parameter] = torch.tensor(
-                    f[parameter][:], dtype=torch.float32
+                    f[parameter][:2], dtype=torch.float32
                 )
 
         # apply conversion function to parameters

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -279,7 +279,7 @@ class ParameterTestingDataset(FlowDataset):
         self.waveforms = torch.stack([cross, plus], dim=0)
         self.parameters = torch.column_stack(params)
         self.background = self.background_from_gpstimes(
-            parameters["gpstime"], self.test_fnames
+            parameters["gpstime"] - 98304000, self.test_fnames
         )
 
         # once we've generated validation/testing waveforms on cpu,

--- a/amplfi/train/data/datasets/testing.py
+++ b/amplfi/train/data/datasets/testing.py
@@ -242,7 +242,7 @@ class ParameterTestingDataset(FlowDataset):
                     continue
 
                 parameters[parameter] = torch.tensor(
-                    f[parameter][:2], dtype=torch.float32
+                    f[parameter][:], dtype=torch.float32
                 )
 
         # apply conversion function to parameters


### PR DESCRIPTION
- Now, we save all the parameters to disk, including those not used for inference
- In addition,  there is now a `datamodule.test_parameters: dict[str, torch.tensor]` attribute that contains all of the waveform parameters, which can be used for importance sampling
- `datamodule.test_inference_parameters: torch.tensor` is now the tensor containing inference parameters 

Relies on #241 