### PR TITLE
Save other extrinsic params in `datamodule.test_parameters`

### DIFF
--- a/amplfi/train/callbacks/testing.py
+++ b/amplfi/train/callbacks/testing.py
@@ -626,6 +626,10 @@ class SaveInjectionParameters(pl.Callback):
     def __init__(self, outdir: Path):
         self.outdir = outdir
 
+    # TODO: should these parameters be saved
+    # regardless of whether this callback is activated?
+    # i.e. should `on_test_epoch_start` and `on_test_batch_end`
+    # be moved to the base dataset?
     def on_test_epoch_start(self, trainer, pl_module: "FlowModel"):
         # initialize field in test parameters for snr
         num_test = len(trainer.datamodule.test_dataloader())

--- a/amplfi/train/callbacks/testing.py
+++ b/amplfi/train/callbacks/testing.py
@@ -629,7 +629,8 @@ class SaveInjectionParameters(pl.Callback):
     def on_test_epoch_start(self, trainer, pl_module: "FlowModel"):
         # initialize field in test parameters for snr
         num_test = len(trainer.datamodule.test_dataloader())
-        trainer.datamodule.test_parameters["snr"] = np.zeros(num_test)
+        for param in ["snr", "dec", "psi", "phi", "ra"]:
+            trainer.datamodule.test_parameters[param] = np.zeros(num_test)
 
     def on_test_epoch_end(self, trainer, pl_module: "FlowModel"):
         # save parameters of randomly sampled injections
@@ -647,6 +648,7 @@ class SaveInjectionParameters(pl.Callback):
         dataloader_idx=0,
     ):
         result: AmplfiResult = outputs
-        trainer.datamodule.test_parameters["snr"][batch_idx] = (
-            result.injection_parameters["snr"]
-        )
+        for param in ["snr", "dec", "psi", "phi", "ra"]:
+            trainer.datamodule.test_parameters[param][batch_idx] = (
+                result.injection_parameters[param]
+            )


### PR DESCRIPTION
- saves sky localization parameters into `datamodule.test_parameters` after they are sampled